### PR TITLE
A unified lsp channel request api

### DIFF
--- a/channel-request.md
+++ b/channel-request.md
@@ -1,0 +1,80 @@
+# LSP channel request
+
+
+## Version: 0.0.1
+
+### /lsp/channel
+
+#### POST
+##### Summary
+
+Request an inbound channel
+
+##### Description
+
+Request an inbound channel with a specific size and duration.
+
+##### Parameters
+
+| Name | Located in | Description | Required | Default | Schema |
+| ---- | ---------- | ----------- | -------- | ------- | ------ |
+| remote_balance | body | Inbound liquidity amount in satoshis | Yes | | integer |
+| local_balance | body | Outbound liqudity amount in satoshis | No | 0 | integer |
+| channel_expiry | body | Channel expiration in weeks | Yes | | integer |
+| node_connection_info | body | pubkey@host:port | Yes | | string |
+
+
+##### Response
+
+| Name | Description | Schema |
+| ---- | ----------- | ------ |
+| order_total | The total fee plus the local_balance requested | number |
+| fee_total | The total fee the lsp will charge to open this channel | number |
+| fee_per_payment | For intercepted payment of fee, fee taken from each payment until fee is paid | number |
+| scid | The scid user puts in the route hint of invoice to identify order | string |
+| ln_invoice | A lightning bolt11 invoice to pay the fee for this channel open | string |
+| btc_address | An on-chain bitcoin address to pay the fee for this channel open | string | 
+| order_id | An lsp generated order id used to look-up the status of this request | string |
+| lnurl_channel | A way to request the open via lnurl after the order is paid | string |
+
+### /lsp/channel
+
+#### GET
+##### Summary
+
+Get information about a channel order
+
+##### Description
+
+Get information about a channel order
+
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| order_id | query | The order_id provided in response to channel request | Yes | string |
+
+##### Response
+
+| Name | Description | Schema |
+| ---- | ----------- | ------ |
+| id | The order id | string |
+| created_at | Number of seconds since epoch when this order was created | number |
+| local_balance | Local balance in sats requested by client | number |
+| remote_balance | Remote balance in sats requested by client | number |
+| channel_expiry | Channel expiry in weeks requested by client | number |
+| channel_expiry_ts | Number of seconds since epoch when the channel can be closed | number |
+| order_expiry_ts | Number of seconds since epoch when this order can still be paid | number |
+| order_total | The total fee plus the local_balance requested | number |
+| fee_total | The total fee the lsp will charge to open this channel | number |
+| fee_per_payment | For intercepted payment of fee, fee taken from each payment until fee is paid | number |
+| scid | The scid user puts in the route hint of invoice to identify order | string |
+| ln_invoice | A lightning bolt11 invoice to pay the fee for this channel open | string |
+| btc_address | An on-chain bitcoin address to pay the fee for this channel open | string | 
+| order_id | An lsp generated order id used to look-up the status of this request | string |
+| lnurl_channel | A way to request the open via lnurl after the order is paid | string |
+| amount_paid | Amount paid by client so far in sats | number |
+| node_connection_info | The node_connection_info for the node to open the channel to | string |
+| channel_open_tx | The txid of the channel funding tx once it is broadcast | string |
+| state | The state of the order | string |
+| onchain_payments | A list of payments received to btc_address on-chain | object[] |

--- a/channel-request.md
+++ b/channel-request.md
@@ -16,12 +16,12 @@ Request an inbound channel with a specific size and duration.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Default | Schema |
-| ---- | ---------- | ----------- | -------- | ------- | ------ |
-| remote_balance | body | Inbound liquidity amount in satoshis | Yes | | integer |
-| local_balance | body | Outbound liqudity amount in satoshis | No | 0 | integer |
-| channel_expiry | body | Channel expiration in weeks | Yes | | integer |
-| node_connection_info | body | pubkey@host:port | Yes | | string |
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ------ |
+| node_connection_info | body | pubkey@host:port | Yes | string |
+| remote_balance | body | Inbound liquidity amount in satoshis | No | integer |
+| local_balance | body | Outbound liqudity amount in satoshis | No | integer |
+| channel_expiry | body | Channel expiration in weeks | No | integer |
 
 
 ##### Response


### PR DESCRIPTION
After thinking through both LSP-intercept and LSP-request I realized (I think) there's a way to enable both with a single relatively simple API.  The request an end-user makes to the LSP can be exactly the same regardless of which method the channel open is to be fulfilled by.

The only information required to initiate an open channel request with an LSP is who to open the channel with (pubkey@host:port).  The size and duration of the channel are recommended but optional parameters.

With that information the LSP is free to determine the cost/fees it will charge for tying up that amount of liquidity for at least the duration requested.  Once the fee calculation is completed it can return to the client the total cost/fees, an on-chain address, a lightning invoice, and a short channel id (scid).

If the client accepts the proposed fee rate from the LSP they are free to pay for the channel however they would like:

- They can send an on-chain payment to the provided btc address.  
- They can pay the bolt11 lightning invoice.  
- They can create an invoice that uses the provided scid as a last hop route hint and have the fee taken from the inbound payment.


The LSP-request spec is largely unchanged here.  It's exactly the same flows.  The user proposes a channel, the lsp sends back the total cost, the user pays using the tx/invoice.  Once it's paid the channel is opened.

The LSP-intercept spec is changed but is the same conceptually.  The user proposes a channel exactly the same was as in LSP-request.  The difference is instead of paying the fee to open the channel directly (via tx/invoice) they are going to pay it via inbound payment(s).

The LSP generates a short channel id to be used in the route hint for the last hop of an invoice.  The client can then use this fee rate and scid to generate invoice(s) to receive payments without opening a channel first.  The LSP can decide if the user must pay the entire fee in a single payment or if it's able to amortize the cost of the channel across many payments.

If they want to force the user to pay the fee in a single payment then they can set fee_per_payment == fee_total.  If they want to allow the user to pay back the fee over multiple payments they can set fee_per_payment < fee_total and each payment that is forwarded will be reduced by fee_per_payment until the fee is paid back.  Their wallet can use GET /channel to understand how much is left to be paid on the order similarly to how they would if they were paying up front using multiple on-chain tx.

I included a first-pass on the POST /channel (create channel open request) and GET /channel (get channel open request by order id) endpoints based on the two specs.

We can incorporate lnurl-channel and the other endpoints (info, finalize channel, etc) if this direction is agreed on.  They are sort of unrelated to the core flow outlined here.