### PR TITLE
(proposal) Add optional on_chain_fee_rate to ChannelOrderRequest

### DIFF
--- a/Open API/LSPS1.json
+++ b/Open API/LSPS1.json
@@ -102,6 +102,10 @@
           "type": "integer",
           "description": "Outbound liquidity amount in satoshis"
         },
+        "on_chain_fee_rate": {
+          "type": "number",
+          "description": "On-chain fee rate of the channel opening transaction in satoshis per vbyte"
+        },
         "channel_expiry": {
           "type": "integer",
           "description": "Channel expiration in weeks. "

--- a/Open API/LSPS1.yaml
+++ b/Open API/LSPS1.yaml
@@ -68,6 +68,9 @@ definitions:
       local_balance:
         type: integer
         description: "Outbound liquidity amount in satoshis"
+      on_chain_fee_rate:
+        type: number
+        description: "On-chain fee rate of the channel opening transaction in satoshis per vbyte"
       channel_expiry:
         type: integer
         description: "Channel expiration in weeks. "

--- a/channel-request.md
+++ b/channel-request.md
@@ -21,6 +21,7 @@ Request an inbound channel with a specific size and duration.
 | node_connection_info | body | pubkey or pubkey@host:port | Yes | string |
 | remote_balance | body | Inbound liquidity amount in satoshis | No | integer |
 | local_balance | body | Outbound liqudity amount in satoshis | No | integer |
+| on_chain_fee_rate | body | On-chain fee rate of the channel opening transaction in satoshis per vbyte | No | number |
 | channel_expiry | body | Channel expiration in weeks | No | integer |
 
 


### PR DESCRIPTION
As a node-runner who sells channels, I want to give users the option to specify the on-chain fee rate of the channel opening transaction as they may have different time preferences. The value they choose here will affect what price I quote for the channel, so I would like for it to be an option in the request.