### PR TITLE
lsps2: match payment_size_msat minimum

### DIFF
--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -796,7 +796,7 @@ where the next hop is `jit_channel_scid`, before
 * MUST set `payment_size_msat` as the forwarded value of the HTLC.
 * MUST compute the `opening_fee` based on the `payment_size_msat`, and
   if the computation overflows, MUST fail with `unknown_next_peer`.
-* MUST check that `opening_fee + htlc_minimum_msat < payment_size_msat`,
+* MUST check that `opening_fee + htlc_minimum_msat <= payment_size_msat`,
   and if that fails, MUST fail with `unknown_next_peer`.
 
 ### 5.  Channel Opening And Forwarding


### PR DESCRIPTION
Small nit: The minimum `payment_size_msat` is smaller than _or equal to_ the fee + `htlc_minimum_msat`. A forward of exactly `htlc_minimum_msat` is eligible for forward as well.