### PR TITLE
LSPS0 Unified Version Negotiation

### DIFF
--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -41,7 +41,6 @@ In general, LSPS1 is developed on the basis that the client trust the LSP to del
 
 ## Order Flow Overview
 
-* Client calls `lsps1.info` to get the LSP's API version and options.
 * Client calls `lsps1.create_order` to create an order.
 * Client pays the order either on-chain or off-chain.
 * LSP opens the channel as soon as they payment is confirmed.
@@ -57,7 +56,7 @@ In general, LSPS1 is developed on the basis that the client trust the LSP to del
 | Idempotent      | Yes        |
 
 
-`lsps1.info` is the entrypoint for each client using the API. It lists the supported versions of the API and all options in a dictionary. 
+`lsps1.info` is the entrypoint for each client using the API. It lists all options in a dictionary. 
 
 - The LSP SHOULD NOT change the values in `lsps1.info` more than once per day.
 
@@ -71,7 +70,6 @@ The client MUST call `lsps1.info` first.
 
 ```JSON
 {
-  "supported_versions": [1],
   "website": "http://example.com/contact",
   "options": {
       "minimum_channel_confirmations": 0,
@@ -89,8 +87,6 @@ The client MUST call `lsps1.info` first.
 }
 ```
 
-- `supported_versions <Array<uint16>>` List of all supported API versions by the LSP.
-  - Client MUST compare the version of the API and therefore ensure compatibility.
 - `website <string>` Website of the LSP.
   - MUST be at most 256 characters long.
 - `options <object>` All options supported by the LSP.
@@ -138,7 +134,6 @@ The request is constructed depending on the client's needs.
 
 ```json
 {
-  "api_version": 1,
   "lsp_balance_sat": "5000000",
   "client_balance_sat": "2000000",
   "confirms_within_blocks": 1,
@@ -150,10 +145,6 @@ The request is constructed depending on the client's needs.
 ```
 
 
-
-- `api_version <uint16>` API version that the client wants to work with.
-  - MUST be `1` for this version of the spec. 
-  - MUST match one of the versions listed in `lsps1.info.supported_versions`.
 - `lsp_balance_sat` <[LSPS0.sat][]> How many satoshi the LSP will provide on their side.
   - MUST be 1 or greater. 
   - MUST be equal or below `base_api.max_initial_lsp_balance_sat`.
@@ -186,7 +177,6 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 ```json
 {
   "order_id": "bb4b5d0a-8334-49d8-9463-90a6d413af7c",
-  "api_version": 1,
   "lsp_balance_sat": "5000000",
   "client_balance_sat": "2000000",
   "confirms_within_blocks": 1,
@@ -219,7 +209,6 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
   - MUST be unique.
   - MUST be at most 64 characters long.
   - SHOULD be a valid [UUID version 4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) (aka random UUID).
-- `api_version <uint16>` Version of the API that has been used to create the order.
 - `lsp_balance_sat` <[LSPS0.sat][]> Mirrored from the request.
 - `client_balance_sat` <[LSPS0.sat][]> Mirrored from the request.
 - `confirms_within_blocks <uint8>` Mirrored from the request.

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -167,32 +167,10 @@ Overview:
 >     factor towards the client / payee, it would also learn the sold
 >     private key.
 
-### 0. API Version
-
-The client can determine the versions supported by the LSP via the
-`lsps2.get_versions` call.
-
-This call takes no parameters `{}` and has no defined errors.
-
-`lsps2.get_versions` has a result like the below:
-
-```JSON
-{
-  "versions": [1]
-}
-```
-
-`versions` is the set of LSPS2 versions the LSP supports.
-When the client later contacts the LSP, it indicates a single specific
-version, which MUST be one of those indicated in this set.
-
-The client MUST determine protocol compatibility (if it supports a
-`version` that the LSP also supports).
-
 ### 1. API Information
 
 `lsps2.get_info` is the entry point for each client using the API.
-It indicates supported versions of this protocol, as well as any limits the
+It indicates any limits the
 LSP imposes, and parameters for payment.
 
 The client MUST request `lsps2.get_info` to read the `opening_fee` of the
@@ -202,13 +180,9 @@ LSP and its related parameters.
 
 ```JSON
 {
-  "version": 1,
   "token": "SECRETDISCOUNTCOUPON100"
 }
 ```
-
-`version` is the version of this spec that will be used for this
-interaction.
 
 `token` is an *optional*, arbitrary JSON string.
 This parameter is intended for use between the client and the LSP; it
@@ -220,8 +194,6 @@ provide any offers, or for any other purpose.
 `lsps2.get_info` has the following errors defined (error code numbers
 in parentheses):
 
-* `unsupported_version` (1) - the LSP does not support the `version`
-  indicated by the client.
 * `unrecognized_or_stale_token` (2) - the client provided the `token`,
   and the LSP does not recognize it, or the token has expired.
 
@@ -560,7 +532,6 @@ Example `lsps2.buy` request parameters:
 
 ```JSON
 {
-    "version": 1,
     "opening_fee_params": {
         "min_fee_msat": "546000",
         "proportional": 1200,
@@ -572,9 +543,6 @@ Example `lsps2.buy` request parameters:
     "payment_size_msat": "42000"
 }
 ```
-
-`version` is the version of this spec that will be used for this
-interaction.
 
 `opening_fee_params` is the object acquired from the previous
 step.
@@ -618,8 +586,6 @@ If the `payment_size_msat` is specified in the request, the LSP:
 
 The following errors are specified for `lsps2.buy`:
 
-* `unsupported_version` (1) - the LSP does not support the
-  specified `version`.
 * `invalid_opening_fee_params` (2) - the `valid_until` field
   of the `opening_fee_params` is already past, **OR** the `promise`
   did not match the parameters.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ All LSPS specifications include a "Status" field.
 
 ## Specs
 
-### **LSPS0** [Transport Layer](LSPS0/README.md)
+### **LSPS0** [Transport Layer](LSPS0/README.md) v1
 Describes the basics of how clients and LSPs communicate to each other.
 
-### **LSPS1** [Channel Request](LSPS1/README.md)
+### **LSPS1** [Channel Request](LSPS1/README.md) v1
 A channel purchase API to buy channels from an LSP.
 
-### **LSPS2** [JIT Channels](LSPS2/README.md)
+### **LSPS2** [JIT Channels](LSPS2/README.md) v1
 Describes how a client can buy channels from an LSP, by paying via a deduction from their incoming payments, creating a channel just-in-time to receive the incoming payment.
 
 ## Services


### PR DESCRIPTION
As agreed in the latest meeting (13th of September), this PR standardizes and unifies the version negotiation for all LSPS.

### Why
Every LSPS includes it's own versioning mechanism anyway so we might as well standardize it. A unified mechanism reduces error sources and complexity. It removes the need for version handling in the LSPS itself. It reduces the number of method calls from one for each LSPS to a single call.

### PR Content

- Adds the method `lsps0.select_versions` to select versions for all LSPS.
- Updates `lsps0.list_protocols` to make it similar to `lsps0.select_versions`.
- Adds a version number to LSPS0 itself. This adds a clear upgrade mechanism in case we need to change anything here. Think of max MTU increase, compression/TLV, or even a complete change in protocol.
- Removes all versioning from the existing LSPS.