### PR TITLE
lsps2: fix extra_fee type number

### DIFF
--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -950,7 +950,7 @@ The LSP MUST ensure that each forwarded part forwards at least
 The LSP MUST ensure that all parts forwarded sum up to at least
 `payment_size_msat - opening_fee`.
 
-The LSP MUST include an `extra_fee` (type 65536) TLV to the
+The LSP MUST include an `extra_fee` (type 65537) TLV to the
 `update_add_htlc` message of forwarded parts that have had
 fees deducted.
 The LSP MUST NOT include this `extra_fee` TLV if the part does


### PR DESCRIPTION
Fix the `extra_fee` TLV type number, which is now odd since 3 months ago: https://github.com/lightning/blips/compare/3692c4661d88d7de5634050e17e29597c351666e..ed6f44e9c450b54312ae84413a96a7211093a094#diff-e8862ebd29b16164d75e36bc4ce2552eb76dafff09daeae8959dc89fdf6408bdR24

