### PR TITLE
Unified Version Proposal: NO VERSIONING

### DIFF
--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -41,7 +41,7 @@ In general, LSPS1 is developed on the basis that the client trust the LSP to del
 
 ## Order Flow Overview
 
-* Client calls `lsps1.info` to get the LSP's API version and options.
+* Client calls `lsps1.info` to get the LSP's options.
 * Client calls `lsps1.create_order` to create an order.
 * Client pays the order either on-chain or off-chain.
 * LSP opens the channel as soon as they payment is confirmed.
@@ -57,7 +57,7 @@ In general, LSPS1 is developed on the basis that the client trust the LSP to del
 | Idempotent      | Yes        |
 
 
-`lsps1.info` is the entrypoint for each client using the API. It lists the supported versions of the API and all options in a dictionary. 
+`lsps1.info` is the entrypoint for each client using the API. It lists all options in a dictionary. 
 
 - The LSP SHOULD NOT change the values in `lsps1.info` more than once per day.
 
@@ -71,7 +71,6 @@ The client MUST call `lsps1.info` first.
 
 ```JSON
 {
-  "supported_versions": [1],
   "website": "http://example.com/contact",
   "options": {
       "minimum_channel_confirmations": 0,
@@ -89,8 +88,6 @@ The client MUST call `lsps1.info` first.
 }
 ```
 
-- `supported_versions <Array<uint16>>` List of all supported API versions by the LSP.
-  - Client MUST compare the version of the API and therefore ensure compatibility.
 - `website <string>` Website of the LSP.
   - MUST be at most 256 characters long.
 - `options <object>` All options supported by the LSP.
@@ -122,7 +119,6 @@ The client MUST call `lsps1.info` first.
 
 Every `min/max` options pair MUST ensure that `min <= max`.
 
-
 **Errors** No additional errors are defined for this method.
 
 ### 2. lsps1.create_order 
@@ -138,7 +134,6 @@ The request is constructed depending on the client's needs.
 
 ```json
 {
-  "api_version": 1,
   "lsp_balance_sat": "5000000",
   "client_balance_sat": "2000000",
   "confirms_within_blocks": 1,
@@ -151,9 +146,6 @@ The request is constructed depending on the client's needs.
 
 
 
-- `api_version <uint16>` API version that the client wants to work with.
-  - MUST be `1` for this version of the spec. 
-  - MUST match one of the versions listed in `lsps1.info.supported_versions`.
 - `lsp_balance_sat` <[LSPS0.sat][]> How many satoshi the LSP will provide on their side.
   - MUST be 1 or greater. 
   - MUST be equal or below `base_api.max_initial_lsp_balance_sat`.
@@ -186,7 +178,6 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 ```json
 {
   "order_id": "bb4b5d0a-8334-49d8-9463-90a6d413af7c",
-  "api_version": 1,
   "lsp_balance_sat": "5000000",
   "client_balance_sat": "2000000",
   "confirms_within_blocks": 1,
@@ -213,7 +204,6 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
   - MUST be unique.
   - MUST be at most 64 characters long.
   - SHOULD be a valid [UUID version 4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) (aka random UUID).
-- `api_version <uint16>` Version of the API that has been used to create the order.
 - `lsp_balance_sat` <[LSPS0.sat][]> Mirrored from the request.
 - `client_balance_sat` <[LSPS0.sat][]> Mirrored from the request.
 - `confirms_within_blocks <uint8>` Mirrored from the request.

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -167,33 +167,10 @@ Overview:
 >     factor towards the client / payee, it would also learn the sold
 >     private key.
 
-### 0. API Version
-
-The client can determine the versions supported by the LSP via the
-`lsps2.get_versions` call.
-
-This call takes no parameters `{}` and has no defined errors.
-
-`lsps2.get_versions` has a result like the below:
-
-```JSON
-{
-  "versions": [1]
-}
-```
-
-`versions` is the set of LSPS2 versions the LSP supports.
-When the client later contacts the LSP, it indicates a single specific
-version, which MUST be one of those indicated in this set.
-
-The client MUST determine protocol compatibility (if it supports a
-`version` that the LSP also supports).
-
 ### 1. API Information
 
 `lsps2.get_info` is the entry point for each client using the API.
-It indicates supported versions of this protocol, as well as any limits the
-LSP imposes, and parameters for payment.
+It indicates any limits the LSP imposes, and parameters for payment.
 
 The client MUST request `lsps2.get_info` to read the `opening_fee` of the
 LSP and its related parameters.
@@ -202,13 +179,9 @@ LSP and its related parameters.
 
 ```JSON
 {
-  "version": 1,
   "token": "SECRETDISCOUNTCOUPON100"
 }
 ```
-
-`version` is the version of this spec that will be used for this
-interaction.
 
 `token` is an *optional*, arbitrary JSON string.
 This parameter is intended for use between the client and the LSP; it
@@ -220,8 +193,6 @@ provide any offers, or for any other purpose.
 `lsps2.get_info` has the following errors defined (error code numbers
 in parentheses):
 
-* `unsupported_version` (1) - the LSP does not support the `version`
-  indicated by the client.
 * `unrecognized_or_stale_token` (2) - the client provided the `token`,
   and the LSP does not recognize it, or the token has expired.
 
@@ -400,14 +371,11 @@ LSPs MUST NOT add any other fields to an `opening_fee_params` object.
 Clients MUST fail and abort the flow if a `opening_fee_params`
 object has unrecognized fields.
 
-> **Rationale** If additional fields are deemed necessary for a
-> future version of this specification, then the `version` should
-> be increased, and a new schema defined for the later `version`.
->
-> Clients that expect this `version` of LSPS2 will compute the
-> `opening_fee` in the manner indicated in this specification, and
-> any additional fields may imply an extension that may mislead
-> the client into computing the wrong `opening_fee`.
+> **Rationale** Clients that expect this version of LSPS2 will
+> compute the `opening_fee` in the manner indicated in this
+> specification, and any additional fields may imply an extension
+> that may mislead the client into computing the wrong
+> `opening_fee`.
 >
 > If the LSP wants to include other information in the
 > `opening_fee_params`, and that information does not affect how
@@ -560,7 +528,6 @@ Example `lsps2.buy` request parameters:
 
 ```JSON
 {
-    "version": 1,
     "opening_fee_params": {
         "min_fee_msat": "546000",
         "proportional": 1200,
@@ -572,9 +539,6 @@ Example `lsps2.buy` request parameters:
     "payment_size_msat": "42000"
 }
 ```
-
-`version` is the version of this spec that will be used for this
-interaction.
 
 `opening_fee_params` is the object acquired from the previous
 step.
@@ -618,8 +582,6 @@ If the `payment_size_msat` is specified in the request, the LSP:
 
 The following errors are specified for `lsps2.buy`:
 
-* `unsupported_version` (1) - the LSP does not support the
-  specified `version`.
 * `invalid_opening_fee_params` (2) - the `valid_until` field
   of the `opening_fee_params` is already past, **OR** the `promise`
   did not match the parameters.
@@ -834,7 +796,7 @@ their [BOLT2 Channel Establishment][] flow:
 > `option_scid_alias` needs to be set so that the channel can be
 > referred to on future invoices before the channel confirms.
 >
-> Future versions of this API may be able to utilize Asynchronous
+> Future revisions of this API may be able to utilize Asynchronous
 > Receive (currently being developed as of this version) to
 > be able to get around the `option_zeroconf` requirement, by
 > treating the receiver / client as offline until the client is
@@ -1029,7 +991,7 @@ negotiated for the new channel.
 > be paid once via the `jit_channel_scid` before it can be issue
 > further invoices with the `alias`.
 >
-> Future versions of this API may allow for more flexibility on the
+> Future revisions of this API may allow for more flexibility on the
 > client side, including support for variable-amount invoices,
 > multiple incoming payments being stalled until the `opening_fee`
 > is achieved and the channel can be opened, and so on.


### PR DESCRIPTION
What is better than unifying versions?  **NOT HAVING TO IMPLEMENT VERSIONS AT ALL**.

The advantages are:

* No more versions.
  * Less code: no need to check versions.
  * Less roundtrips: no questioning of versions and selecting the version.
* Much less amibiguity in specifications:
  * Do we have separate "For implementation", "Stable" etc. states for each VERSION or for each LSPS?

In particular, we SHOULD in fact separate LSPS2 from LSPS4 (***YES*** @SeverinAlexB ***I AM CHANGING MY MIND ABOUT THIS***).  The reason is that LSPS2 has  *fundamentally different flow* from LSPS4:

* LSPS2:
  * Get quotes on how much JIT channels cost.
  * Buy an SCID.
  * Issue invoice
  * Receive payment and get JIT channel opened.
* LSPS4:
  * Get the permanent SCID
  * Issue invoice.
  * Receive payment notification. If it fits in current inbound liquidity, use it and end the flow.  Otherwise continue...
  * Get quotes on how much JIT channels cost.
  * Buy a JIT channel open.
  * Reeive payment and get JIT channel opened.

Thus, we ***MUST*** in fact put them as separate specifications completely, because they the fundamental differences in flow.

Even with no-version, we can still upgrade individual specifications:

* We can add optional parameters to API requests:
  * If not specified, run back-compatibly with previous versions.
  * If specified, new version.  If LSP does not recognize, use standard "parameter error" `-32602` from JSON-RPC 2.0 so that client knows LSP does not support new version.
* We can add new fields in API responses or LSP notifications:
  * LSPS0 specifically requires that clients ignore unrecognized fields in responses and notifications.
  * If client knows it but it does not appear, then LSP is on older version.

Basically:

* If the changes are big enough that they cannot fit in the above back-compatibility, then we really MUST put them in a new LSPS.
* Otherwise, the changes are small enough that they do not need a separate LSPS but can fit in the same flow as an existing LSPS.

Putting LSPS2 and LSPS4 specifically in separate LSPS numbers also makes it much easier to reason about the LSPS states "For Implementation" "Stable" and "Deprecated".  Until LSPS4 is stable, we should not deprecate LSPS2.  If we move LSPS4 as LSPS2v2 then we need separate states for *each version* of an LSPS.

No-version FTW.