### PR TITLE
Add minimum_fee_for_0conf

### DIFF
--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -193,7 +193,8 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
     "order_total_sat": "2008888",
     "lightning_invoice": "lnbc252u1p3aht9ysp580g4633gd2x9lc5al0wd8wx0mpn9748jeyz46kqjrpxn52uhfpjqpp5qgf67tcqmuqehzgjm8mzya90h73deafvr4m5705l5u5l4r05l8cqdpud3h8ymm4w3jhytnpwpczqmt0de6xsmre2pkxzm3qydmkzdjrdev9s7zhgfaqxqyjw5qcqpjrzjqt6xptnd85lpqnu2lefq4cx070v5cdwzh2xlvmdgnu7gqp4zvkus5zapryqqx9qqqyqqqqqqqqqqqcsq9q9qyysgqen77vu8xqjelum24hgjpgfdgfgx4q0nehhalcmuggt32japhjuksq9jv6eksjfnppm4hrzsgyxt8y8xacxut9qv3fpyetz8t7tsymygq8yzn05",
     "onchain_address": "bc1p5uvtaxzkjwvey2tfy49k5vtqfpjmrgm09cvs88ezyy8h2zv7jhas9tu4yr",
-    "min_onchain_payment_confirmations	": 0,
+    "min_onchain_payment_confirmations": 0,
+    "min_fee_for_0conf": 253,
     "onchain_payment": null
   },
   "channel": null
@@ -295,7 +296,7 @@ This section describes the `payment` object returned by `lsps1.create_order` and
     "order_total_sat": "2008888",
     "bolt11_invoice": "lnbc252u1p3aht9ysp580g4633gd2x9lc5al0wd8wx0mpn97...",
     "onchain_address": "bc1p5uvtaxzkjwvey2tfy49k5vtqfpjmrgm09cvs88ezyy8h2zv7jhas9tu4yr",
-    "min_onchain_payment_confirmations	": 1,
+    "min_onchain_payment_confirmations": 1,
     "min_fee_for_0conf": 253,
     "onchain_payment": {
         "outpoint": "0301e0480b374b32851a9462db29dc19fe830a7f7d7a88b81612b9d42099c0ae:1",


### PR DESCRIPTION
The example response for `lsps1.create_order` did not comply to the spec. It should be a `Payment`-object which requires the `minimum_fee_for_0conf` field to be present.