### PR TITLE
LSPS1: Consistent variable naming

### DIFF
--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -75,7 +75,7 @@ The client MUST call `lsps1.info` first.
   "website": "http://example.com/contact",
   "options": {
       "minimum_channel_confirmations": 0,
-      "minimum_onchain_payment_confirmations": 1,
+      "min_onchain_payment_confirmations": 1,
       "supports_zero_channel_reserve": true,
       "min_onchain_payment_size_sat": null,
       "max_channel_expiry_blocks": 20160,
@@ -97,7 +97,7 @@ The client MUST call `lsps1.info` first.
   - `minimum_channel_confirmations <unit8>` Minimum number of block confirmations before the LSP accepts a channel as confirmed and sends [channel_ready](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-channel_ready-message) (previously `funding_locked`).
     - MAY be 0 to allow 0conf channels.
     - MUST be 0 or greater.
-  - `minimum_onchain_payment_confirmations <unit8>` Minimum number of block confirmations before the LSP accepts an on-chain payment as confirmed. This is a lower bound. The LSP MAY increase this value by responding with a different value in `lsps1.create_order.onchain_block_confirmations_required` depending on the size of the channels and risk management.
+  - `min_onchain_payment_confirmations <unit8>` Minimum number of block confirmations before the LSP accepts an on-chain payment as confirmed. This is a lower bound. The LSP MAY increase this value by responding with a different value in `lsps1.create_order.min_onchain_payment_confirmations	` depending on the size of the channels and risk management.
     - MAY be 0 to allow 0conf payments.
     - MUST be 0 or greater.
   - `supports_zero_channel_reserve <boolean>` Indicates if the LSP supports [zeroreserve](https://github.com/ElementsProject/lightning/pull/5315).
@@ -202,7 +202,7 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
     "order_total_sat": "2008888",
     "lightning_invoice": "lnbc252u1p3aht9ysp580g4633gd2x9lc5al0wd8wx0mpn9748jeyz46kqjrpxn52uhfpjqpp5qgf67tcqmuqehzgjm8mzya90h73deafvr4m5705l5u5l4r05l8cqdpud3h8ymm4w3jhytnpwpczqmt0de6xsmre2pkxzm3qydmkzdjrdev9s7zhgfaqxqyjw5qcqpjrzjqt6xptnd85lpqnu2lefq4cx070v5cdwzh2xlvmdgnu7gqp4zvkus5zapryqqx9qqqyqqqqqqqqqqqcsq9q9qyysgqen77vu8xqjelum24hgjpgfdgfgx4q0nehhalcmuggt32japhjuksq9jv6eksjfnppm4hrzsgyxt8y8xacxut9qv3fpyetz8t7tsymygq8yzn05",
     "onchain_address": "bc1p5uvtaxzkjwvey2tfy49k5vtqfpjmrgm09cvs88ezyy8h2zv7jhas9tu4yr",
-    "onchain_block_confirmations_required": 0,
+    "min_onchain_payment_confirmations	": 0,
     "onchain_payment": null
   },
   "channel": null
@@ -305,7 +305,7 @@ This section describes the `payment` object returned by `lsps1.create_order` and
     "order_total_sat": "2008888",
     "bolt11_invoice": "lnbc252u1p3aht9ysp580g4633gd2x9lc5al0wd8wx0mpn97...",
     "onchain_address": "bc1p5uvtaxzkjwvey2tfy49k5vtqfpjmrgm09cvs88ezyy8h2zv7jhas9tu4yr",
-    "onchain_block_confirmations_required": 1,
+    "min_onchain_payment_confirmations	": 1,
     "minimum_fee_for_0conf": 253,
     "onchain_payment": {
         "outpoint": "0301e0480b374b32851a9462db29dc19fe830a7f7d7a88b81612b9d42099c0ae:1",
@@ -332,12 +332,12 @@ This section describes the `payment` object returned by `lsps1.create_order` and
       - `options.min_onchain_payment_size_sat` is greater than `order_total_sat`.
       - `options.min_onchain_payment_size_sat` is `null` and on-chain payments are therefore not supported.
       - `refund_onchain_address` is `null`.
-- `required_onchain_block_confirmations <uint8>` Minimum number of block confirmations that are required for the on-chain payment to be considered confirmed.
-    - MUST be equal or greater than `options.minimum_onchain_payment_confirmations`.
+- `min_onchain_payment_confirmations <uint8>` Minimum number of block confirmations that are required for the on-chain payment to be considered confirmed.
+    - MUST be equal or greater than `options.min_onchain_payment_confirmations`.
     - MUST be `null` if `onchain_address` is `null`.
 - `minimum_fee_for_0conf <LSPS0.onchain_fee>` Fee rate for on-chain payment in case the client wants the payment to be confirmed without a confirmation.
     - MUST be `null` if `onchain_address` is `null`.
-    - MUST be `null` if `required_onchain_block_confirmations` is greater than 0.
+    - MUST be `null` if `min_onchain_payment_confirmations` is greater than 0.
     - SHOULD choose a high enough fee to lower the risk of a double spend.
 - `onchain_payment <object>` Detected on-chain payment.
     - MUST contain the incoming/confirmed outpoint to `onchain_address`.
@@ -346,7 +346,7 @@ This section describes the `payment` object returned by `lsps1.create_order` and
     - `sat` <[LSPS0.sat][]> MUST contain the received satoshi.
     - `confirmed <boolean>` Indicates if the LSP sees the transaction as confirmed.
 
-> **Rationale `required_onchain_block_confirmations`** The main risk for an LSP is that the client pays the on-chain payment and then double spends the transaction. This is especially critical in case the client requested a high `client_balance`. Opening a 0conf channel alone has no risk attached to it IF the on-chain payment is confirmed. Therefore, the LSP can mitigate this risk by waiting for a certain number of block confirmations before opening the channel.
+> **Rationale `min_onchain_payment_confirmations`** The main risk for an LSP is that the client pays the on-chain payment and then double spends the transaction. This is especially critical in case the client requested a high `client_balance`. Opening a 0conf channel alone has no risk attached to it IF the on-chain payment is confirmed. Therefore, the LSP can mitigate this risk by waiting for a certain number of block confirmations before opening the channel.
 
 > **Rationale `minimum_fee_for_0conf`** The client MAY want to have instant confirmation of the on-chain payment. The LSP can mitigate the risk of a double spend by requiring a high fee rate. The client can then decide if he wants to pay the high fee rate or wait for the on-chain payment to be confirmed once.
 
@@ -380,12 +380,12 @@ This section describes the `payment` object returned by `lsps1.create_order` and
 **LSP** Payment confirmation
 
 - MUST monitor the blockchain and update `onchain_payment`.
-- IF `onchain_block_confirmations_required` is 0 and incoming transaction fee is greater than `minimum_fee_for_0conf`:
+- IF `min_onchain_payment_confirmations	` is 0 and incoming transaction fee is greater than `minimum_fee_for_0conf`:
   - SHOULD set the transaction as confirmed.
-- IF `onchain_block_confirmations_required` is equal or greater than 1:
-  - SHOULD set the transaction as confirmed after `onchain_block_confirmations_required` confirmations.
-- MAY always set the transaction as confirmed before `onchain_block_confirmations_required` confirmations.
-- In rare circumstances, MAY take longer than `onchain_block_confirmations_required` confirmations in case the LSP doesn't trust the transaction.
+- IF `min_onchain_payment_confirmations	` is equal or greater than 1:
+  - SHOULD set the transaction as confirmed after `min_onchain_payment_confirmations	` confirmations.
+- MAY always set the transaction as confirmed before `min_onchain_payment_confirmations	` confirmations.
+- In rare circumstances, MAY take longer than `min_onchain_payment_confirmations	` confirmations in case the LSP doesn't trust the transaction.
 - MUST always set the transaction as confirmed after 6 block confirmations.
 
 
@@ -403,9 +403,9 @@ This section describes the `payment` object returned by `lsps1.create_order` and
 
 **0conf risk management**
 
-Every LSP that accepts 0conf transactions is responsible to do their own risk management. `minimum_onchain_payment_confirmations` and `minimum_fee_for_0conf` are the risk management tools the LSP has. The main risk lies in the fact that the client can double spend the on-chain payment. Opening a 0conf channel is not risky for the LSP anymore if the LSP is sure of the on-chain payment.
+Every LSP that accepts 0conf transactions is responsible to do their own risk management. `min_onchain_payment_confirmations` and `minimum_fee_for_0conf` are the risk management tools the LSP has. The main risk lies in the fact that the client can double spend the on-chain payment. Opening a 0conf channel is not risky for the LSP anymore if the LSP is sure of the on-chain payment.
 
-`minimum_onchain_payment_confirmations` and `minimum_fee_for_0conf` are the best estimates of the LSP makes at the time of the order creation. These estimates MAY change over time so the LSP MAY confirm a transaction earlier or later. Therefore, the client MUST NOT rely on the LSP confirming the transaction within the given time frame.
+`min_onchain_payment_confirmations` and `minimum_fee_for_0conf` are the best estimates of the LSP makes at the time of the order creation. These estimates MAY change over time so the LSP MAY confirm a transaction earlier or later. Therefore, the client MUST NOT rely on the LSP confirming the transaction within the given time frame.
 
 
 ### 4. Channel


### PR DESCRIPTION
- Resolved an issue where `onchain_block_confirmations_required` and `required_onchain_block_confirmations` are used interchangeably.
- Consistently prefer `min_` over `minimum_` in variable names


