### PR TITLE
LSPS2: Add `temporary_channel_id` to `lsps2.buy` response

### DIFF
--- a/LSPS0/common-schemas.md
+++ b/LSPS0/common-schemas.md
@@ -146,6 +146,22 @@ encoding, would be written as the JSON string `"539268x845x1"`.
 > format for SCIDs, and helps separate the SCID type from other
 > types.
 
+### Channel Identifiers (Channel IDs)
+
+###### Link: LSPS0.channel_id
+
+Channel identifiers are the 32-byte `channel_id`s as defined in the [BOLT2
+Definition of `channel_id`], i.e., the big-endian XOR of funding transaction's
+`txid` and `output_index`, encoded encoded as a hex string.
+
+In contexts where the case is significant (for example, if it
+will be committed to by some hash or signature) then the
+representation MUST be in lowercase.
+Otherwise, readers MUST allow both lowercase and uppercase
+hexadecimal digits.
+
+[BOLT2 Definition of `channel_id`]: https://github.com/lightning/bolts/blob/29c14c6e12cbdf33f6b724094c81658a614d2e02/02-peer-protocol.md#definition-of-channel_id
+
 ### SECP256K1 Points / Public Keys / Lightning Network Node IDs
 
 ###### Link: LSPS0.pubkey

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -601,6 +601,7 @@ Example successful `lsps2.buy` result:
 ```JSON
 {
     "jit_channel_scid": "1x4815x29451",
+    "temporary_channel_id": "82581bfe75e8808b66f92974725276efe245e3fc72c821fcaa77d893de4cdc6b"
     "lsp_cltv_expiry_delta" : 144,
     "client_trusts_lsp": false
 }
@@ -610,13 +611,21 @@ Example successful `lsps2.buy` result:
 the invoice [<LSPS0.scid>][],
 and `lsp_cltv_expiry_delta` is the CLTV delta for that route hint hop.
 
+`temporary_channel_id` is the random 32-byte `temporary_channel_id` in that the
+LSP is going to use when sending the [`open_channel` message], in big-endian
+hex string encoding [<LSPS0.channel_id>][]. It allows the client to link the
+channel opening request with its previously made LSPS2 buy request.
+
 `client_trusts_lsp` is an *optional* Boolean.
 If not specified, it defaults to `false`.
 If specified and `true`, the client MUST trust the LSP to actually
 create and confirm a valid channel funding transaction.
 
+
 The client MAY abort the flow if the LSP specified `client_trusts_lsp`
 as `true` in the result.
+
+[`open_channel` message]: https://github.com/lightning/bolts/blob/f7dcc32694b8cd4f3a1768b904f58cb177168f29/02-peer-protocol.md#the-open_channel-message
 
 ### 3.  Invoice Generation
 


### PR DESCRIPTION
Previously, an LSPS2 client had no unambiguous way to link an incoming channel opening from the LSP to a specific LSPS2 buy request it issued earlier. 

In order to give the client the capability to correlate which channel was opened as a result of which request, we here require the LSP to send the `temporary_channel_id` it is going to use for the channel opening in the response to `lsps2.buy`.

It may generally be up for discussion if we want to do this, as our consensus is to not add any new functionality to LSPS2. If we still want to touch it at all, this might be a reasonable addition.