### PR TITLE
LSPS1: Semantics of `confirms_within_blocks`

### DIFF
--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -74,8 +74,8 @@ The client MUST call `lsps1.get_info` first.
 {
   "website": "http://example.com/contact",
   "options": {
-      "min_required_channel_confirmations": 6,
-      "min_funding_confirms_within_blocks" : 0,
+      "min_required_channel_confirmations": 0,
+      "min_funding_confirms_within_blocks" : 6,
       "min_onchain_payment_confirmations": null,
       "supports_zero_channel_reserve": true,
       "min_onchain_payment_size_sat": null,
@@ -161,8 +161,8 @@ The request is constructed depending on the client's needs.
   - MUST be greater or equal `base_api.min_initial_client_balance_sat`.
 - `required_channel_confirmations <uint8>` Number of confirmations the funding tx must have before the LSP sends `channel_ready`
   - MUST be greater or equal to `base_api.min_required_channel_confirmations`
-  - LSP MAY always confirm the channel faster then requested
-- `funding_confirms_within_blocks <uint8>` Number of blocks the client wants to wait maximally until the funding transaction is confirmed.
+  - LSP MAY always confirm the channel faster than requested
+- `funding_confirms_within_blocks <uint8>` The maximum number of blocks the client wants to wait until the funding transaction is confirmed.
   - MUST be greater or equal to `base_api.min_funding_confirms_within_blocks`
   - LSP MAY always confirm the funding transaction faster than requested.
 - `channel_expiry_blocks <uint32>` How long the channel is leased for in block time.
@@ -459,11 +459,11 @@ In case the channel open failed
 **LSP**
 
 - MAY open channels in batches, opening multiple channels in one transaction.
-  - the LSP MUST still ensure that the funding transaction gets confirmed after a maximum of `funding_confirms_within_blocks after the client payment completed.
+  - The LSP MUST still ensure that the funding transaction gets confirmed within `funding_confirms_within_blocks` blocks after the client payment completed.
 
-For orders where `required_channel_confirmations=0` the LSP MUST attempt to open the channel immediately after receiving the payments.
+For orders where `required_channel_confirmations = 0` the LSP MUST attempt to open the channel immediately after receiving the payment.
 
-> **Rationale `funding_confirms_within_blocks** We use `funding_confirms_within_blocks` instead of `fee_rate` to allow the LSP to batch the channel. For example, if a client orders a channel within 5 blocks, the LSP may wait to publish the funding transaction for 3 blocks to batch channels and add a fee to the funding transaction to ensure it confirms within 2 blocks.
+> **Rationale `funding_confirms_within_blocks** We use `funding_confirms_within_blocks` instead of `fee_rate` to allow the LSP to batch channel funding transactions. For example, if a client orders a channel within five blocks, the LSP may wait to publish the funding transaction for three blocks to batch channel openings and add a fee to the funding transaction to ensure it confirms within two blocks.
 
 
 


### PR DESCRIPTION
The change is quite subtle but the intent becomes clear when you apply
it to a few examples.

## Before this commit

The `confirms_within_blocks` is an upper bound on the number of
- blocks between payment and funding-tx-confirmed (See [link](https://github.com/BitcoinAndLightningLayerSpecs/lsp/blob/d07cbb0bcdc1942c4970e4a2ac46f87c63dbdf33/LSPS1/README.md?plain=1#L449C7-L449C154))
- blocks between payment and channel_ready (See [link](https://github.com/BitcoinAndLightningLayerSpecs/lsp/blob/d07cbb0bcdc1942c4970e4a2ac46f87c63dbdf33/LSPS1/README.md?plain=1#L157C36-L157C119))

The `min_channel_confirmations` is the number of confirmations of the funding-tx before sending a `channel_ready`.

```
payment_confirmed            funding tx confirmed            channel_ready
    |                             |                               |
    |                             |                               |
    |<--confirms_within_blocks--->|                               |
    |                             |                               |
    |<--------------------confirms_within_blocks----------------->|
    |                             |                               |
    |                             |<--min_channel_confirmations-->|
    |                             |                               |
```

First, I want to point out that `min_channel_confirmations` is an LSP-wide configuration.
It should be specified in the order just like `confirms_within_blocks`.

The second problem is that the semantics `confirms_within_blocks` confusing.
It has two meanings that are spread out across the document.

The set of chosen parameters also poorly communicates the intent of a
transaction.

A client wants a 0-conf channel. Should it set `confirms_within_blocks=0`?
No, in that case the server MUST confirm the funding transaction in 0
blocks. This wouldn't be feasible.

Should the client set `confirms_within_blocks` sufficiently high to give the LSP-server
the opportunity to get the funding tx confirmed?

Maybe, but how would a client that wants to wait a few blocks and is
fine with batching communicate their intent. It can only set
`confirms_within_blocks` sufficiently high.

| Intent | `confirms_within_blocks` |
|--------|--------------------------|
| Client requests a zero-conf channel | 6 |
| Client wants to use a channel within 6 blocks and is prepared to wait for batching | 6 |

## Changes in this commit

We define `confirms_within_blocks` as the amount of blocks between the
payment is confirmed and the funding tx is confirmed. (Single meaning)

We keep the definition of `min_channel_confirmations`. However, we require
the client to put this number explicitly in the order.

If `min_channel_confirmations=0` the server MUST open the channel immediately
after receiving payment

```
payment                 funding tx confirmed                   channel ready
  |                                  |                               |
  |                                  |                               |
  |<--confirms_within_blocks-------->|                               |
  |                                  |                               |
  |                                  |<--min_channel_confirmations-->|
  |                                  |                               |
  |                                  |                               |
```

| `confirms_within_blocks` | `min_channel_confirmations` | Meaning                                                                                                       |
|---|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 0 | 0 | Not allowed. The LSP cannot confirm a transaction within 0 blocks.                                                                                             |
| 6 | 0 | A zero-conf channel. The LSP should ensure the funding tx is confirmed within 6 blocks                                                                         |
| 6 | 1 | The LSP should ensure the funding tx is confirmed within 6 blocks after receiving the payment. It can still wait one more block until it sends `channel_ready` |