### PR TITLE
LSPS2: `{min,max}_payment_size_msat` clarifications

### DIFF
--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -207,6 +207,8 @@ Example `lsps2.get_info` result:
             "valid_until": "2023-02-23T08:47:30.511Z",
             "min_lifetime": 1008,
             "max_client_to_self_delay": 2016,
+            "min_payment_size_msat": "1000",
+            "max_payment_size_msat": "1000000",
             "promise": "abcdefghijklmnopqrstuvwxyz"
         },
         {
@@ -215,11 +217,11 @@ Example `lsps2.get_info` result:
             "valid_until": "2023-02-27T21:23:57.984Z",
             "min_lifetime": 1008,
             "max_client_to_self_delay": 2016,
+            "min_payment_size_msat": "1000",
+            "max_payment_size_msat": "1000000",
             "promise": "abcdefghijklmnopqrstuvwxyz"
         }
-    ],
-    "min_payment_size_msat": "1000",
-    "max_payment_size_msat": "1000000",
+    ]
 }
 ```
 The `opening_fee_params_menu` is an array of `opening_fee_params`
@@ -227,9 +229,9 @@ objects.
 The LSP MAY return an empty array; in which case, the client currently
 cannot use JIT Channels with this LSP.
 
-An `opening_fee_params` object describes how much the LSP will charge
-for a channel open, and until when the described fee rates will be
-considered valid.
+An `opening_fee_params` object describes how much the LSP will charge for a
+channel open, what payment sizes it will accept, and until when the described
+parameters will be considered valid.
 An `opening_fee_params` object MUST have all of the following fields,
 and MUST NOT have any additional fields:
 
@@ -264,6 +266,12 @@ and MUST NOT have any additional fields:
   The client-side `to_self_delay` is the delay imposed on the LSP to recover
   the funds in case the LSP has to perform a unilateral close on the channel
   and defines the security of the client against malign or hacked LSPs.
+* `min_payment_size_msat` and `max_payment_size_msat` are the limits of the
+  payment size, inclusive.
+  These are strings containing decimal numbers, in millisatoshis
+  [<LSPS0.msat>][].
+  The payment size is the amount that the payer is guarateed to be able to send
+  to the client, not including the forwarding fees of nodes along the way.
 * `promise` is an arbitrary LSP-generated string that proves to the LSP that
   it has promised a specific `opening_fee_params` with the specific
   `min_fee_msat`, `proportional`, `valid_until`, `min_lifetime`, and
@@ -386,13 +394,6 @@ object has unrecognized fields.
 > the `promise` can be used to determine whether this information
 > exists or not, and the LSP can cut the added information in this
 > `promise` from the cryptographic commitment.
-
-`min_payment_size_msat` and `max_payment_size_msat` are the limits of the
-payment size, inclusive.
-These are strings containing decimal numbers, in millisatoshis
-[<LSPS0.msat>][].
-The payment size is the amount that the payer will send to the
-client, not including the forwarding fees of nodes along the way.
 
 The client now takes the `opening_fee_params` and the expected
 `payment_size_msat`, to compute the `opening_fee`, and determine if the
@@ -534,6 +535,8 @@ Example `lsps2.buy` request parameters:
         "valid_until": "2023-02-23T08:47:30.511Z",
         "min_lifetime": 1008,
         "max_client_to_self_delay": 2016,
+        "min_payment_size_msat": "1000",
+        "max_payment_size_msat": "1000000",
         "promise": "abcdefghijklmnopqrstuvwxyz"
     },
     "payment_size_msat": "42000"
@@ -565,10 +568,6 @@ The client MUST ensure that `payment_size_msat` is within the previous
 `min_payment_size_msat` and `max_payment_size_msat` parameters from the LSP.
 The LSP MUST validate that the `payment_size_msat` is within the previous
 `min_payment_size_msat` and `max_payment_size_msat` parameters from the LSP.
-
-> **Non-normative** The LSP may have the `min_payment_size_msat` and
-> `max_payment_size_msat` parameters as configuration-time constants,
-> or may embed them in the `promise` field of the `opening_fee_params`.
 
 If the `payment_size_msat` is specified in the request, the LSP:
 

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -270,7 +270,7 @@ and MUST NOT have any additional fields:
   payment size, inclusive.
   These are strings containing decimal numbers, in millisatoshis
   [<LSPS0.msat>][].
-  The payment size is the amount that the payer is guarateed to be able to send
+  The payment size is the amount that the payer is guaranteed to be able to send
   to the client, not including the forwarding fees of nodes along the way.
 * `promise` is an arbitrary LSP-generated string that proves to the LSP that
   it has promised a specific `opening_fee_params` with the specific
@@ -410,8 +410,8 @@ For a given `payment_size_msat` (in millisatoshis) and a selected
         opening_fee = min_fee_msat
 
 * All numbers MUST be computed in unsigned 64-bit integers.
-  * Clients and LSPs MAY use arbitarry-precision integers, such as
-    Haskell `Integer` type or bignums in Lisplike languages, IF AND
+  * Clients and LSPs MAY use arbitrary-precision integers, such as
+    Haskell `Integer` type or bignums in Lisp-like languages, IF AND
     ONLY IF they check for overflow of unsigned 64-bit at each basic
     arithmetic operation.
 * Integer division MUST round down; the `+ 9999999` causes this to

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -569,15 +569,17 @@ The client MUST ensure that `payment_size_msat` is within the previous
 The LSP MUST validate that the `payment_size_msat` is within the previous
 `min_payment_size_msat` and `max_payment_size_msat` parameters from the LSP.
 
-If the `payment_size_msat` is specified in the request, the LSP:
-
-* MUST compute the `opening_fee` and check that the computation
-  did not hit an overflow failure.
-  * MUST check that the resulting `opening_fee` is strictly less
-    than the `payment_size_msat`.
-* SHOULD check that it has sufficient incoming liquidity from the
-  public network to be able to receive at least `payment_size_msat`,
-  if it was specified.
+* If the `payment_size_msat` is specified in the request, the LSP:
+    * MUST compute the `opening_fee` and check that the computation
+      did not hit an overflow failure.
+      * MUST check that the resulting `opening_fee` is strictly less
+        than the `payment_size_msat`.
+    * SHOULD check that it has sufficient incoming liquidity from the
+      public network to be able to receive at least `payment_size_msat`.
+* otherwise:
+    * SHOULD validate that the size of a received variable-amount payment is
+      within the previous `min_payment_size_msat` and `max_payment_size_msat`
+      parameters before forwarding the payment.
 
 The following errors are specified for `lsps2.buy`:
 


### PR DESCRIPTION
Previously, the `min_payment_size_msat` and `max_payment_size_msat`
fields were part of the `lsps2.get_info` response, but were not part of
the opening fee parameters the LSP commits to. It was however remarked
that the LSP *may* include them in the `promise` field.

Here, we make the latter non-optional and move the fields into the
`opening_fee_params`. This has three main benefits:

1) The payment size limits are non-negotiable, possibly per-request boundaries the LSP enforces and
   hence they should be clearly communicated and committed to via the `promise`.
2) The LSP may want to take different fee rates depending on the
   payment size limits, e.g., take a higher fee in exchange for allowing
   higher payment sizes.
3) *If* the LSP so far included them in the `promise` calculation, it
   was required to keep track of them for each `get_info` response it
   previously handed out to the users. Moving the fields into the
   `opening_fee_params` allows it to not keep any state between
   `lsps2.get_info` and `lsps2.buy`, decoupling these two steps further.

We also clarify that the limits apply to variable-amount payments as we we should clearly
define what limits the client can expect, even in the var-amount case.