### PR TITLE
LSPS2: Remove `option_zeroconf` requirement.

### DIFF
--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -802,32 +802,16 @@ side.
 The LSP and client MUST negotiate these options and parameters in
 their [BOLT2 Channel Establishment][] flow:
 
-* `option_zeroconf` is set.
 * `option_scid_alias` is set.
 * `announce_channel` is `false`.
 * The client-provided `to_self_delay` is less than or equal to
   the agreed-upon `max_client_to_self_delay`.
 
-> **Rationale** `option_zeroconf` is set so that the payment can
-> be immediately forwarded to the client and resolved as soon as
-> the opening negotiation completes; if the client and LSP had to
-> wait for confirmation, the incoming payment would have to be
-> locked for an extended period, which is indistinguishable from
-> a channel jamming attack.
-> `option_zeroconf` cannot be set unless `announce_channel` is
-> `false`.
-> `option_scid_alias` needs to be set so that the channel can be
-> referred to on future invoices before the channel confirms.
+> **Rationale** `option_scid_alias` needs to be set so that the
+> channel can be referred to on future invoices before the channel
+> confirms.
 >
-> Future revisions of this API may be able to utilize Asynchronous
-> Receive (currently being developed as of this version) to
-> be able to get around the `option_zeroconf` requirement, by
-> treating the receiver / client as offline until the client is
-> online *and* the JIT channel to it is deeply confirmed, if the
-> LSP and client negotiate a non-`option_zeroconf` channel for
-> the JIT channel.
-> A non-`option_zeroconf` JIT channel could also be later
-> published with `announce_channel = true`.
+> `option_scid_alias` requires that `announce_channel` be `false`.
 
 Clients MAY reject the channel open attempt if any other
 parameters or options are not desired by the client (for example,


### PR DESCRIPTION
It turns out that some node implementations simply cannot set `option_zeroconf` in the `open_channel` message, i.e. they have no API that lets this to be set. This prevents such implementations from being used in to implement LSPS2.

The zero-confirmation need is already expressed elsewhere in LSPS2 regarding the timing of `channel_ready` being done immediately after `funding_signed`:

```Markdown
Depending on the `client_trusts_lsp` from the `lsps2.buy` result,
after the client has sent `funding_signed` and the LSP is willing
to broadcast the funding transaction:

* If `client_trusts_lsp` is specified and `true`:
  * The LSP MAY wait for the client to send the preimage to the
    incoming payment via a `update_fulfill_htlc` before broadcasting
    the funding transaction.
  * The client MUST NOT wait for the LSP to broadcast the funding
    transaction before sending the preimage via a 
    `update_fulfill_htlc`.
  * The client and LSP MUST immediately send `channel_ready`.
* If `client_trusts_lsp` is unspecified or `false`:
  * The client MAY wait for the funding transaction to appear in
    its mempool or the mempool of a trusted node, or confirmed in a
    block with any depth, AND confirm that the funding transaction
    output is correct, before sending `channel_ready`.
  * The LSP MUST immediately broadcast the channel funding
    transaction and send `channel_ready`.
  * The client MAY immediately send `channel_ready` (i.e. the
    client trusts the LSP, even though the LSP does not require
    that trust).
```

There is thus no real need to signal `option_zeroconf` explicitly.

Existing LSP implementations of LSPS2 that CAN signal `option_zeroconf` need not change --- there is **no** new verbiage that `option_zeroconf` MUST NOT be set, so setting `option_zeroconf` is free for the LSP. However, clients do need to be modified to no longer check for `option_zeroconf` existing and `announce_channel=false`.

@tnull @TheBlueMatt