### PR TITLE
LSPS0: Clarify JSON-RPC error codes

### DIFF
--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -87,7 +87,7 @@ even though not mentioned here.
 
 [JSON-RPC error codes]: https://www.jsonrpc.org/specification#error_object
 
-Any LSPS building on top of LSPS0 that defines custom errors MUST use the `-32000 to -32099 Server error` range as described in the [JSON-RPC error codes][].
+Any LSPS building on top of LSPS0 that defines custom errors MUST still use the `-32000 to -32099 Server error` range as described in the [JSON-RPC error codes][].
 
 ---
 

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -77,6 +77,18 @@ by the [JSON-RPC 2.0][] protocol.
 
 [JSON-RPC 2.0]: https://www.jsonrpc.org/specification
 
+---
+**Error codes** In general, the client, the LSP, and any LSPS building on top of LSPS0 MUST respect
+[JSON-RPC error codes][]. 
+This document extends the error codes by describing edge cases
+combining [JSON-RPC 2.0][] with [BOLT8][]. Any error code like `-32603 Internal error` is still valid
+even though not mentioned here.
+
+[JSON-RPC error codes]: https://www.jsonrpc.org/specification#error_object
+
+Any LSPS building on top of LSPS0 that defines custom errors MUST use the `-32000 to -32099 Server error` range as described in the [JSON-RPC error codes][].
+---
+
 If a client or LSP receives a BOLT8 message with message ID
 37913, it MUST perform the checks below.
 If any of these checks fail, then the incoming message has

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -450,15 +450,21 @@ In that case, the LSP would respond with:
 ##### Custom Errors
 
 [JSON-RPC 2.0][] protocol defines the range of `-31999 to +32767` (inclusive) to be application defined errors.
-Each LSPS is provided and MUST use an error range of max 100 error codes. The range for each LSPS is calculated as follow: `LSPS-number * 100 to LSPS-number * 100 + 99` (inclusive).
+Each LSPS is provided and MUST use an error range of max 100 error codes. 
+The range for each LSPS is calculated as follow: `LSPS-number * 100 to LSPS-number * 100 + 99` (inclusive).
 
 For example:
 - LSPS0: `00000 to 00099`
 - LSPS1: `00100 to 00199`
 - LSPS2: `00200 to 00299`
 
-And so on until `+32699`. The range of `-31999 to -1` (inclusive) is undefined and MAY be used by applications outside of the LSPSpec. 
-Such applications MAY request the spec group to register an error code range to avoid collision.
+And so on until `+32699`. The range of `-31999 to -1` (inclusive) is undefined 
+and MAY be used by applications outside of the LSPSpec. Such applications MAY request 
+the spec group to register an error code range to avoid collision.
+
+As per the [JSON-RPC 2.0][] protocol, the range between `-32000 to -32099` are 
+"reserved for implementation-defined server-errors". These error codes MAY be used by LSPs 
+too. Clients MUST treat an error in this range similar to a `-32603	Internal error` if not know otherwise.
 
 
 #### Disconnection Handling

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -449,8 +449,8 @@ In that case, the LSP would respond with:
 
 ##### Custom Errors
 
-[JSON-RPC](https://www.jsonrpc.org/specification#error_object) protocol defines the range of `-31999 to +32767` (inclusive) to be application defined errors.
-Each LSPS MUST use an error range of 100 error codes. The error range for each LSPS can be calculated as follow: `LSPS-number * 100 to LSPS-number * 100 + 99` (inclusive).
+[JSON-RPC 2.0][] protocol defines the range of `-31999 to +32767` (inclusive) to be application defined errors.
+Each LSPS is provided and MUST use an error range of 100 error codes. The range for each LSPS can be calculated as follow: `LSPS-number * 100 to LSPS-number * 100 + 99` (inclusive).
 
 For example:
 - LSPS0: `00000 to 00099`
@@ -458,7 +458,7 @@ For example:
 - LSPS2: `00200 to 00299`
 
 And so on until `+32699`. The range of `-31999 to -1` (inclusive) is undefined and MAY be used by applications outside of the LSPSpec. 
-Such applications MAY request the spec group to register an error code range to avoid colitions.
+Such applications MAY request the spec group to register an error code range to avoid collision.
 
 
 #### Disconnection Handling

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -462,9 +462,9 @@ And so on until `+32699`. The range of `-31999 to -1` (inclusive) is undefined
 and MAY be used by applications outside of the LSPSpec. Such applications MAY request 
 the spec group to register an error code range to avoid collision.
 
-As per the [JSON-RPC 2.0][] protocol, the range between `-32000 to -32099` are 
+As per [JSON-RPC 2.0][], the range between `-32000 to -32099` are 
 "reserved for implementation-defined server-errors". These error codes MAY be used by LSPs 
-too. Clients MUST treat an error in this range similar to a `-32603	Internal error` if not know otherwise.
+too. Clients MUST treat an error in this range similar to a `-32603 Internal error` if it does not know otherwise.
 
 
 #### Disconnection Handling

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -77,7 +77,6 @@ by the [JSON-RPC 2.0][] protocol.
 
 [JSON-RPC 2.0]: https://www.jsonrpc.org/specification
 
-
 If a client or LSP receives a BOLT8 message with message ID
 37913, it MUST perform the checks below.
 If any of these checks fail, then the incoming message has
@@ -450,7 +449,17 @@ In that case, the LSP would respond with:
 
 ##### Custom Errors
 
-Any LSPS building on top of LSPS0 that defines custom errors MUST use the `-32000 to -32099 Server error` range described in the [JSON-RPC error codes][].
+[JSON-RPC](https://www.jsonrpc.org/specification#error_object) protocol defines the range of `-31999 to +32767` (inclusive) to be application defined errors.
+Each LSPS MUST use an error range of 100 error codes. The error range for each LSPS can be calculated as follow: `LSPS-number * 100 to LSPS-number * 100 + 99` (inclusive).
+
+For example:
+- LSPS0: `00000 to 00099`
+- LSPS1: `00100 to 00199`
+- LSPS2: `00200 to 00299`
+
+And so on until `+32699`. The range of `-31999 to -1` (inclusive) is undefined and MAY be used by applications outside of the LSPSpec. 
+Such applications MAY request the spec group to register an error code range to avoid colitions.
+
 
 #### Disconnection Handling
 

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -77,19 +77,6 @@ by the [JSON-RPC 2.0][] protocol.
 
 [JSON-RPC 2.0]: https://www.jsonrpc.org/specification
 
----
-
-**Error codes** In general, the client, the LSP, and any LSPS building on top of LSPS0 MUST respect
-[JSON-RPC error codes][]. 
-This document extends the error codes by describing edge cases
-combining [JSON-RPC 2.0][] with [BOLT8][]. Any error code like `-32603 Internal error` is still valid
-even though not mentioned here.
-
-[JSON-RPC error codes]: https://www.jsonrpc.org/specification#error_object
-
-Any LSPS building on top of LSPS0 that defines custom errors MUST still use the `-32000 to -32099 Server error` range as described in the [JSON-RPC error codes][].
-
----
 
 If a client or LSP receives a BOLT8 message with message ID
 37913, it MUST perform the checks below.
@@ -356,6 +343,16 @@ Other LSPS specifications MUST:
 
 #### Error Handling
 
+In general, the client, the LSP, and any LSPS building on top of LSPS0 MUST respect
+[JSON-RPC error codes][]. 
+This document extends the error codes by describing edge cases
+combining [JSON-RPC 2.0][] with [BOLT8][]. Any error code like `-32603 Internal error` is still valid
+even though not mentioned here explicitly.
+
+[JSON-RPC error codes]: https://www.jsonrpc.org/specification#error_object
+
+---
+
 JSON-RPC 2.0 `error`s include a `message` field which is a
 human-readable error message.
 
@@ -450,6 +447,10 @@ In that case, the LSP would respond with:
 > However, without the `unrecognized` field in the `data` object,
 > the client cannot know if the LSP does not support
 > `future_feature1_param`, `future_feature2_param`, or both.
+
+##### Custom Errors
+
+Any LSPS building on top of LSPS0 that defines custom errors MUST use the `-32000 to -32099 Server error` range described in the [JSON-RPC error codes][].
 
 #### Disconnection Handling
 

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -347,7 +347,7 @@ In general, the client, the LSP, and any LSPS building on top of LSPS0 MUST resp
 [JSON-RPC error codes][]. 
 This document extends the error codes by describing edge cases
 combining [JSON-RPC 2.0][] with [BOLT8][]. Any error code like `-32603 Internal error` is still valid
-even though not mentioned here explicitly.
+even though not mentioned explicitly.
 
 [JSON-RPC error codes]: https://www.jsonrpc.org/specification#error_object
 

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -78,6 +78,7 @@ by the [JSON-RPC 2.0][] protocol.
 [JSON-RPC 2.0]: https://www.jsonrpc.org/specification
 
 ---
+
 **Error codes** In general, the client, the LSP, and any LSPS building on top of LSPS0 MUST respect
 [JSON-RPC error codes][]. 
 This document extends the error codes by describing edge cases
@@ -87,6 +88,7 @@ even though not mentioned here.
 [JSON-RPC error codes]: https://www.jsonrpc.org/specification#error_object
 
 Any LSPS building on top of LSPS0 that defines custom errors MUST use the `-32000 to -32099 Server error` range as described in the [JSON-RPC error codes][].
+
 ---
 
 If a client or LSP receives a BOLT8 message with message ID

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -450,7 +450,7 @@ In that case, the LSP would respond with:
 ##### Custom Errors
 
 [JSON-RPC 2.0][] protocol defines the range of `-31999 to +32767` (inclusive) to be application defined errors.
-Each LSPS is provided and MUST use an error range of 100 error codes. The range for each LSPS can be calculated as follow: `LSPS-number * 100 to LSPS-number * 100 + 99` (inclusive).
+Each LSPS is provided and MUST use an error range of max 100 error codes. The range for each LSPS is calculated as follow: `LSPS-number * 100 to LSPS-number * 100 + 99` (inclusive).
 
 For example:
 - LSPS0: `00000 to 00099`

--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -462,7 +462,7 @@ And so on until `+32699`. The range of `-31999 to -1` (inclusive) is undefined
 and MAY be used by applications outside of the LSPSpec. Such applications MAY request 
 the spec group to register an error code range to avoid collision.
 
-As per [JSON-RPC 2.0][], the range between `-32000 to -32099` are 
+As per [JSON-RPC 2.0][], the range between `-32000 to -32099` is 
 "reserved for implementation-defined server-errors". These error codes MAY be used by LSPs 
 too. Clients MUST treat an error in this range similar to a `-32603 Internal error` if it does not know otherwise.
 

--- a/LSPS0/common-schemas.md
+++ b/LSPS0/common-schemas.md
@@ -378,7 +378,7 @@ Example:
 
 Commonly shared error codes that are used in multiple LSPS.
 
-#### 1 Client rejected
+#### 001 Client rejected
 
 ###### Link: LSPS0.client_rejected_error
 
@@ -386,7 +386,7 @@ A LSP MAY return a `Client rejected` error in case it does not want to offer a s
 
 | Code | Message         | Data                             | Description                  |
 | ---- | --------------- | -------------------------------- | ---------------------------- |
-| 1    | Client rejected | {"message": %human_message% }    | The LSP rejected the client. |
+| 001  | Client rejected | {"message": %human_message% }    | The LSP rejected the client. |
 
 - `%human_message% <string>` A human readable message that indicates why the lsp rejected the client.
   - May simply be `{ "message": "Client rejected" }`.

--- a/LSPS0/common-schemas.md
+++ b/LSPS0/common-schemas.md
@@ -374,6 +374,23 @@ Example:
 }
 ```
 
+### Error Codes
+
+Commonly shared error codes that are used in multiple LSPS.
+
+#### 001 Client rejected
+
+###### Link: LSPS0.client_rejected_error
+
+A LSP MAY return a `LSPS0.client_rejected_error` error in case it does not want to offer a service to the client.
+Mostly used in case the client misbehaves.
+
+| Code | Message         | Data                             | Description                  |
+| ---- | --------------- | -------------------------------- | ---------------------------- |
+| 1    | Client rejected | {"message": %human_message% }    | The LSP rejected the client. |
+
+- `%human_message% <string>` A human readable message that indicates why the lsp rejected the client.
+
 
 ## References
 

--- a/LSPS0/common-schemas.md
+++ b/LSPS0/common-schemas.md
@@ -378,18 +378,18 @@ Example:
 
 Commonly shared error codes that are used in multiple LSPS.
 
-#### 001 Client rejected
+#### 1 Client rejected
 
 ###### Link: LSPS0.client_rejected_error
 
-A LSP MAY return a `LSPS0.client_rejected_error` error in case it does not want to offer a service to the client.
-Mostly used in case the client misbehaves.
+A LSP MAY return a `Client rejected` error in case it does not want to offer a service to the client. A LSP MAY reject a client by its node_id or IP for example.
 
 | Code | Message         | Data                             | Description                  |
 | ---- | --------------- | -------------------------------- | ---------------------------- |
 | 1    | Client rejected | {"message": %human_message% }    | The LSP rejected the client. |
 
 - `%human_message% <string>` A human readable message that indicates why the lsp rejected the client.
+  - May simply be `{ "message": "Client rejected" }`.
 
 
 ## References

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -234,8 +234,8 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 | Code   | Message         | Data | Description |
 | ----   | -------         | ----------- | ---- |
 | -32602 | Invalid params  | {"property": %invalid_property%, "message": %human_message% }    | Invalid method parameter(s). |
-| 101    | Option mismatch |  {"property": %option_mismatch_property%, "message": %human_message% }   | The order doesnt match the options defined in `lsps1.get_info.options`. |
-| 102    | Client rejected |  {"message": %human_message% }   | The LSP rejected the client. |
+| 100    | Option mismatch |  {"property": %option_mismatch_property%, "message": %human_message% }   | The order doesnt match the options defined in `lsps1.get_info.options`. |
+| 101    | Client rejected |  {"message": %human_message% }   | The LSP rejected the client. |
 
 - LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `101` error in case of a mismatch.
   - `%option_mismatch_property%` MUST be one of the fields in `lsps1.get_info.options`.
@@ -278,7 +278,7 @@ The client MAY check the current status of the order at any point.
 
 | Code   | Message   | Data    | Description                                           |
 | ------ | --------- | ------- | ----------------------------------------------------- |
-| 100    | Not found | {}      | Order with the requested order_id has not been found. |
+| 102    | Not found | {}      | Order with the requested order_id has not been found. |
 
 
 ### 3. Payment

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -233,9 +233,9 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 
 | Code   | Message         | Data | Description |
 | ----   | -------         | ----------- | ---- |
-| -32602 | Invalid params  | {"property": %invalid_property%, "message": %human_message% }    | Invalid method parameter(s). |
-| 100    | Option mismatch |  {"property": %option_mismatch_property%, "message": %human_message% }   | The order doesnt match the options defined in `lsps1.get_info.options`. |
-| 101    | Client rejected |  {"message": %human_message% }   | The LSP rejected the client. |
+| -32602 | Invalid params  | {"property": %invalid_property%, "message": %human_message% }            | Invalid method parameter(s). |
+| 100    | Option mismatch | {"property": %option_mismatch_property%, "message": %human_message% }    | The order doesnt match the options defined in `lsps1.get_info.options`. |
+| 001    | Client rejected | {"message": %human_message% }                                            | [LSPS0.client_rejected_error][] |
 
 - LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `101` error in case of a mismatch.
   - `%option_mismatch_property%` MUST be one of the fields in `lsps1.get_info.options`.
@@ -466,3 +466,4 @@ In case the channel open failed
 [LSPS0.outpoint]: ../LSPS0/common-schemas.md#link-lsps0outpoint
 [LSPS0.scid]: ../LSPS0/common-schemas.md#link-lsps0scid
 [LSPS0.txid]: ../LSPS0/common-schemas.md#link-lsps0txid
+[LSPS0.client_rejected_error]: ../LSPS0/common-schemas.md#link-lsps0.client_rejected_error

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -234,10 +234,10 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 | Code   | Message         | Data | Description |
 | ----   | -------         | ----------- | ---- |
 | -32602 | Invalid params  | {"property": %invalid_property%, "message": %human_message% }    | Invalid method parameter(s). |
-| 1000   | Option mismatch |  {"property": %option_mismatch_property%, "message": %human_message% }   | The order doesnt match the options defined in `lsps1.get_info.options`. |
-| 1001   | Client rejected |  {"message": %human_message% }   | The LSP rejected the client. |
+| 101    | Option mismatch |  {"property": %option_mismatch_property%, "message": %human_message% }   | The order doesnt match the options defined in `lsps1.get_info.options`. |
+| 102    | Client rejected |  {"message": %human_message% }   | The LSP rejected the client. |
 
-- LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `1000` error in case of a mismatch.
+- LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `101` error in case of a mismatch.
   - `%option_mismatch_property%` MUST be one of the fields in `lsps1.get_info.options`.
   - Example: `{ "property": "min_initial_client_balance_sat" }`.
 
@@ -249,7 +249,7 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 
 > **Rationale `token` validation** The client should be informed if the token is invalid. Ignoring the invalid token and creating an order without the potentially discount or other side effect is not good UX. Ignoring the invalid token will also NOT prevent anybody bruteforcing the token because the client will still detect if the LSP has given a discount.
 
-- LSP MAY reject a client by it's node_id or IP. In this case, the LSP MUST return a `1001` error.
+- LSP MAY reject a client by it's node_id or IP. In this case, the LSP MUST return a `102` error.
   - %human_message% MAY simply be "Client rejected".
   - Example: `{ "message": "Client rejected" }`.
 
@@ -278,7 +278,7 @@ The client MAY check the current status of the order at any point.
 
 | Code   | Message   | Data    | Description                                           |
 | ------ | --------- | ------- | ----------------------------------------------------- |
-| 404    | Not found | {}      | Order with the requested order_id has not been found. |
+| 100    | Not found | {}      | Order with the requested order_id has not been found. |
 
 
 ### 3. Payment

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -235,9 +235,9 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 | ----   | -------         | ----------- | ---- |
 | -32602 | Invalid params  | {"property": %invalid_property%, "message": %human_message% }            | Invalid method parameter(s). |
 | 100    | Option mismatch | {"property": %option_mismatch_property%, "message": %human_message% }    | The order doesnt match the options defined in `lsps1.get_info.options`. |
-| 001    | Client rejected | {"message": %human_message% }                                            | [LSPS0.client_rejected_error][] |
+| 1    | Client rejected | {"message": %human_message% }                                            | [LSPS0.client_rejected_error][] |
 
-- LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `101` error in case of a mismatch.
+- LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `100` error in case of a mismatch.
   - `%option_mismatch_property%` MUST be one of the fields in `lsps1.get_info.options`.
   - Example: `{ "property": "min_initial_client_balance_sat" }`.
 
@@ -248,10 +248,6 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 - LSP MUST validate the `token` field and return an error if the token is invalid.
 
 > **Rationale `token` validation** The client should be informed if the token is invalid. Ignoring the invalid token and creating an order without the potentially discount or other side effect is not good UX. Ignoring the invalid token will also NOT prevent anybody bruteforcing the token because the client will still detect if the LSP has given a discount.
-
-- LSP MAY reject a client by it's node_id or IP. In this case, the LSP MUST return a `102` error.
-  - %human_message% MAY simply be "Client rejected".
-  - Example: `{ "message": "Client rejected" }`.
 
 > **Rationale Client rejected** LSPs can reject a client for example for misbehaviour. LSPs can reject a node on two levels: Prevent a peer connection OR disable order creation. Preventing a peer connection might not work in case you still want to allow other functions to keep working, for example an existing channel.
 
@@ -278,7 +274,7 @@ The client MAY check the current status of the order at any point.
 
 | Code   | Message   | Data    | Description                                           |
 | ------ | --------- | ------- | ----------------------------------------------------- |
-| 102    | Not found | {}      | Order with the requested order_id has not been found. |
+| 101    | Not found | {}      | Order with the requested order_id has not been found. |
 
 
 ### 3. Payment

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -235,7 +235,7 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 | ----   | -------         | ----------- | ---- |
 | -32602 | Invalid params  | {"property": %invalid_property%, "message": %human_message% }            | Invalid method parameter(s). |
 | 100    | Option mismatch | {"property": %option_mismatch_property%, "message": %human_message% }    | The order doesnt match the options defined in `lsps1.get_info.options`. |
-| 1    | Client rejected | {"message": %human_message% }                                            | [LSPS0.client_rejected_error][] |
+| 001    | Client rejected | {"message": %human_message% }                                            | [LSPS0.client_rejected_error][] |
 
 - LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `100` error in case of a mismatch.
   - `%option_mismatch_property%` MUST be one of the fields in `lsps1.get_info.options`.

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -462,4 +462,4 @@ In case the channel open failed
 [LSPS0.outpoint]: ../LSPS0/common-schemas.md#link-lsps0outpoint
 [LSPS0.scid]: ../LSPS0/common-schemas.md#link-lsps0scid
 [LSPS0.txid]: ../LSPS0/common-schemas.md#link-lsps0txid
-[LSPS0.client_rejected_error]: ../LSPS0/common-schemas.md#link-lsps0.client_rejected_error
+[LSPS0.client_rejected_error]: ../LSPS0/common-schemas.md#link-lsps0client_rejected_error

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -234,8 +234,9 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 | Code   | Message         | Data | Description |
 | ----   | -------         | ----------- | ---- |
 | -32602 | Invalid params  | {"property": %invalid_property%, "message": %human_message% }            | Invalid method parameter(s). |
-| 100    | Option mismatch | {"property": %option_mismatch_property%, "message": %human_message% }    | The order doesnt match the options defined in `lsps1.get_info.options`. |
 | 001    | Client rejected | {"message": %human_message% }                                            | [LSPS0.client_rejected_error][] |
+| 100    | Option mismatch | {"property": %option_mismatch_property%, "message": %human_message% }    | The order doesnt match the options defined in `lsps1.get_info.options`. |
+
 
 - LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `100` error in case of a mismatch.
   - `%option_mismatch_property%` MUST be one of the fields in `lsps1.get_info.options`.

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -582,13 +582,13 @@ If the `payment_size_msat` is specified in the request, the LSP:
 
 The following errors are specified for `lsps2.buy`:
 
-* `invalid_opening_fee_params` (200) - the `valid_until` field
+* `invalid_opening_fee_params` (201) - the `valid_until` field
   of the `opening_fee_params` is already past, **OR** the `promise`
   did not match the parameters.
-* `payment_size_too_small` (201) - the `payment_size_msat` was specified,
+* `payment_size_too_small` (202) - the `payment_size_msat` was specified,
   and the resulting `opening_fee` is equal or greater than the
   `payment_size_msat`.
-* `payment_size_too_large` (202) - the `payment_size_msat` was specified,
+* `payment_size_too_large` (203) - the `payment_size_msat` was specified,
   and the LSP hit an overflow error while calculating the
   `opening_fee`, **OR** the LSP has insufficient incoming liquidity
   from the public network to receive the `payment_size_msat`.

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -193,7 +193,7 @@ provide any offers, or for any other purpose.
 `lsps2.get_info` has the following errors defined (error code numbers
 in parentheses):
 
-* `unrecognized_or_stale_token` (2) - the client provided the `token`,
+* `unrecognized_or_stale_token` (200) - the client provided the `token`,
   and the LSP does not recognize it, or the token has expired.
 
 Example `lsps2.get_info` result:
@@ -582,13 +582,13 @@ If the `payment_size_msat` is specified in the request, the LSP:
 
 The following errors are specified for `lsps2.buy`:
 
-* `invalid_opening_fee_params` (2) - the `valid_until` field
+* `invalid_opening_fee_params` (201) - the `valid_until` field
   of the `opening_fee_params` is already past, **OR** the `promise`
   did not match the parameters.
-* `payment_size_too_small` (3) - the `payment_size_msat` was specified,
+* `payment_size_too_small` (202) - the `payment_size_msat` was specified,
   and the resulting `opening_fee` is equal or greater than the
   `payment_size_msat`.
-* `payment_size_too_large` (4) - the `payment_size_msat` was specified,
+* `payment_size_too_large` (203) - the `payment_size_msat` was specified,
   and the LSP hit an overflow error while calculating the
   `opening_fee`, **OR** the LSP has insufficient incoming liquidity
   from the public network to receive the `payment_size_msat`.

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -582,13 +582,13 @@ If the `payment_size_msat` is specified in the request, the LSP:
 
 The following errors are specified for `lsps2.buy`:
 
-* `invalid_opening_fee_params` (201) - the `valid_until` field
+* `invalid_opening_fee_params` (200) - the `valid_until` field
   of the `opening_fee_params` is already past, **OR** the `promise`
   did not match the parameters.
-* `payment_size_too_small` (202) - the `payment_size_msat` was specified,
+* `payment_size_too_small` (201) - the `payment_size_msat` was specified,
   and the resulting `opening_fee` is equal or greater than the
   `payment_size_msat`.
-* `payment_size_too_large` (203) - the `payment_size_msat` was specified,
+* `payment_size_too_large` (202) - the `payment_size_msat` was specified,
   and the LSP hit an overflow error while calculating the
   `opening_fee`, **OR** the LSP has insufficient incoming liquidity
   from the public network to receive the `payment_size_msat`.


### PR DESCRIPTION
As discussed in #86, LSPS0 was confusing on error codes that were not specifically mention in LSPS0.

This PR adds clarifying sentences.

CC @tnull 