### PR TITLE
LSPS1 & LSPS2: Fix error codes to adhere to JSON-RPC 2.0 Spec

### DIFF
--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -234,8 +234,8 @@ The client MUST check if [option_support_large_channel](https://bitcoinops.org/e
 | Code   | Message         | Data | Description |
 | ----   | -------         | ----------- | ---- |
 | -32602 | Invalid params  | {"property": %invalid_property%, "message": %human_message% }    | Invalid method parameter(s). |
-| 1000   | Option mismatch |  {"property": %option_mismatch_property%, "message": %human_message% }   | The order doesnt match the options defined in `lsps1.get_info.options`. |
-| 1001   | Client rejected |  {"message": %human_message% }   | The LSP rejected the client. |
+| -32000   | Option mismatch |  {"property": %option_mismatch_property%, "message": %human_message% }   | The order doesnt match the options defined in `lsps1.get_info.options`. |
+| -32001  | Client rejected |  {"message": %human_message% }   | The LSP rejected the client. |
 
 - LSP MUST validate the order against the options defined in `lsps1.get_info.options`. LSP MUST return an `1000` error in case of a mismatch.
   - `%option_mismatch_property%` MUST be one of the fields in `lsps1.get_info.options`.
@@ -276,9 +276,9 @@ The client MAY check the current status of the order at any point.
 
 **Errors**
 
-| Code   | Message   | Data    | Description                                           |
-| ------ | --------- | ------- | ----------------------------------------------------- |
-| 404    | Not found | {}      | Order with the requested order_id has not been found. |
+| Code      | Message   | Data    | Description                                           |
+| --------- | --------- | ------- | ----------------------------------------------------- |
+| -32000    | Not found | {}      | Order with the requested order_id has not been found. |
 
 
 ### 3. Payment

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -193,7 +193,7 @@ provide any offers, or for any other purpose.
 `lsps2.get_info` has the following errors defined (error code numbers
 in parentheses):
 
-* `unrecognized_or_stale_token` (2) - the client provided the `token`,
+* `unrecognized_or_stale_token` (-32002) - the client provided the `token`,
   and the LSP does not recognize it, or the token has expired.
 
 Example `lsps2.get_info` result:
@@ -582,13 +582,13 @@ If the `payment_size_msat` is specified in the request, the LSP:
 
 The following errors are specified for `lsps2.buy`:
 
-* `invalid_opening_fee_params` (2) - the `valid_until` field
+* `invalid_opening_fee_params` (-32002) - the `valid_until` field
   of the `opening_fee_params` is already past, **OR** the `promise`
   did not match the parameters.
-* `payment_size_too_small` (3) - the `payment_size_msat` was specified,
+* `payment_size_too_small` (-32003) - the `payment_size_msat` was specified,
   and the resulting `opening_fee` is equal or greater than the
   `payment_size_msat`.
-* `payment_size_too_large` (4) - the `payment_size_msat` was specified,
+* `payment_size_too_large` (-32004) - the `payment_size_msat` was specified,
   and the LSP hit an overflow error while calculating the
   `opening_fee`, **OR** the LSP has insufficient incoming liquidity
   from the public network to receive the `payment_size_msat`.


### PR DESCRIPTION
As described in #86 and #88, the error codes of LSPS1 and LSPS2 were not adhering to the [JSON-RPC 2.0 Error Spec](https://www.jsonrpc.org/specification#error_object). The error codes should be in the `-32000 to -32099 Server error` range.

This PR fixes this.

cc: @tnull 