### PR TITLE
chore: Add implementations to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Describes how a client can buy channels from an LSP, by paying via a deduction f
 
 LSPSpec implementations in no specific order:
 
-- [LDK - lightning liquidity](https://crates.io/crates/lightning-liquidity) LSPS0, LSPS1, LSPS2
+- [LDK - lightning liquidity](https://github.com/lightningdevkit/lightning-liquidity) LSPS0, LSPS1, LSPS2
 - [LND - balanceofsatoshi](https://github.com/alexbosworth/balanceofsatoshis/tree/master/lsp) LSPS0, LSPS1
 - [CLN - cln-lightning-liquidity](https://github.com/niteshbalusu11/cln-lightning-liquidity) LSPS0, LSPS1
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ A channel purchase API to buy channels from an LSP.
 ### **LSPS2** [JIT Channels](LSPS2/README.md)
 Describes how a client can buy channels from an LSP, by paying via a deduction from their incoming payments, creating a channel just-in-time to receive the incoming payment.
 
+## Implementations
+
+LSPSpec implementations in no specific order:
+
+- [LDK - lightning liquidity](https://crates.io/crates/lightning-liquidity) LSPS0, LSPS1, LSPS2
+- [LND - balanceofsatoshi](https://github.com/alexbosworth/balanceofsatoshis/tree/master/lsp) LSPS0, LSPS1
+- [CLN - cln-lightning-liquidity](https://github.com/niteshbalusu11/cln-lightning-liquidity) LSPS0, LSPS1
+
 ## Services
 List of Lightning Service Providers in alphabetic order that currently or will support LSP specs in future.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ LSPSpec implementations in no specific order:
 - [LDK - lightning liquidity](https://github.com/lightningdevkit/lightning-liquidity) LSPS0, LSPS1, LSPS2
 - [LND - balanceofsatoshi](https://github.com/alexbosworth/balanceofsatoshis/tree/master/lsp) LSPS0, LSPS1
 - [CLN - cln-lightning-liquidity](https://github.com/niteshbalusu11/cln-lightning-liquidity) LSPS0, LSPS1
+- [CLN/LND - Breez lspd](https://github.com/breez/lspd) LSPS0, LSPS2
 
 ## Services
 List of Lightning Service Providers in alphabetic order that currently or will support LSP specs in future.


### PR DESCRIPTION
Adds implementations to the LSPSpec main readme. Closes #76.

FYI: @tnull @niteshbalusu11 @alexbosworth