### PR TITLE
LSPS0: LSP-server advertising is optional

### DIFF
--- a/LSPS0/README.md
+++ b/LSPS0/README.md
@@ -508,11 +508,11 @@ context.
 > gossip and inspecting the channel-graph.
 > The bit 729 was chosen randomly and has no special meaning.
 
-LSPs MUST set the `features` bit 729 `option_supports_lsps` if it
-supports at least LSPS0, and MUST set the `features` bit even if it
+LSPs MAY set the `features` bit 729 `option_supports_lsps` if it
+supports at least LSPS0, and MAY set the `features` bit even if it
 does not support some of the LSPS specifications.
 
-> **Rationale** This specification also describes a `listprotocols`
+> **Rationale** This specification also describes a `lsps0.list_protocols`
 > API which the LSP uses to report exactly which LSPS specifications
 > it supports.
 


### PR DESCRIPTION
We falsely implied that an LSP MUST set feature-bit 729.
I've fixed the wording.

This is a replacement for https://github.com/BitcoinAndLightningLayerSpecs/lsp/pull/99