### PR TITLE
LSPS2: Fix `jit_channel_scid` example

### DIFF
--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -602,7 +602,7 @@ Example successful `lsps2.buy` result:
 
 ```JSON
 {
-    "jit_channel_scid": "1x4815x29451",
+    "jit_channel_scid": "29451x4815x1",
     "lsp_cltv_expiry_delta" : 144,
     "client_trusts_lsp": false
 }


### PR DESCRIPTION
According to LSPS0 common schemas the SCIDs are represented using the common `BBBxTTTxOOO` schema. The example previously given in LSPS2 however seems to follow `000xTTTxBBB`.

Here, we change the example to adhere to the expected schema.