### PR TITLE
Encode fields in `opening_fee_params` promise

### DIFF
--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -390,9 +390,7 @@ Clients, when reading the `promise` field:
 > A size limit is imposed so that LSPs cannot burden clients with
 > unreasonable storage requirements.
 
-LSPs MUST NOT add any other fields to an `opening_fee_params` object.
-
-Clients MUST fail and abort the flow if a `opening_fee_params`
+Clients MAY fail and abort the flow if a `opening_fee_params`
 object has unrecognized fields.
 
 > **Rationale** Clients that expect this version of LSPS2 will
@@ -410,6 +408,14 @@ object has unrecognized fields.
 > the `promise` can be used to determine whether this information
 > exists or not, and the LSP can cut the added information in this
 > `promise` from the cryptographic commitment.
+>
+> It is possible that in the future this spec adds additional backward
+> compatible fields to the `opening_fee_params` object. Clients may therefore
+> also choose to ignore unrecognized fields in order to allow for backward
+> compatible upgrade paths. Since the LSP can commit to any random data in the
+> promise that the client may not be able to read, there is no real harm in
+> ignoring additional fields. The client has an incentive to understand the
+> newly added fields, because they might give a discount.
 
 The client now takes the `opening_fee_params` and the expected
 `payment_size_msat`, to compute the `opening_fee`, and determine if the

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -545,28 +545,19 @@ Example `lsps2.buy` request parameters:
 
 ```JSON
 {
-    "opening_fee_params": {
-        "min_fee_msat": "546000",
-        "proportional": 1200,
-        "valid_until": "2023-02-23T08:47:30.511Z",
-        "min_lifetime": 1008,
-        "max_client_to_self_delay": 2016,
-        "min_payment_size_msat": "1000",
-        "max_payment_size_msat": "1000000",
-        "promise": "abcdefghijklmnopqrstuvwxyz"
-    },
+    "promise": "abcdefghijklmnopqrstuvwxyz",
     "payment_size_msat": "42000"
 }
 ```
 
-`opening_fee_params` is the object acquired from the previous
-step.
+`promise` is taken from an `opening_fee_params` object acquired from the
+previous step.
 Clients MUST copy it verbatim from an entry of `opening_fee_params_menu`
 from a result of a `lsps2.get_info` call.
-LSPs MUST check that the `opening_fee_params.promise` does in fact
-prove that it previously promised the specified `opening_fee_params`.
-LSPs MUST check that the `opening_fee_params.valid_until` is not a
-past datetime.
+LSPs MUST check that the `promise` does in fact prove that it previously
+committed to a specific `opening_fee_params` object.
+LSPs MUST check that the `opening_fee_params.valid_until` encoded in the
+`promise` is not a past datetime.
 
 `payment_size_msat` is an *optional* amount denominated in millisatoshis
 that the client wants to receive [<LSPS0.msat>][]:
@@ -599,9 +590,9 @@ The LSP MUST validate that the `payment_size_msat` is within the previous
 
 The following errors are specified for `lsps2.buy`:
 
-* `invalid_opening_fee_params` (201) - the `valid_until` field
-  of the `opening_fee_params` is already past, **OR** the `promise`
-  did not match the parameters.
+* `invalid_promise` (201) - the `promise` could not be decoded, **OR** the
+  `promise` could not be verified with the LSP's rules, **OR** the `valid_until`
+  field of the associated `opening_fee_params` has already past.
 * `payment_size_too_small` (202) - the `payment_size_msat` was specified,
   and the resulting `opening_fee` is equal or greater than the
   `payment_size_msat`.

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -312,6 +312,12 @@ the following rules:
 
 The LSP, when generating the `promise` field:
 
+* MUST encode all fields of the `opening_fee_params` into the `promise` in such
+  a way that the `opening_fee_params` object can be reconstructed from the
+  `promise`. This spec does not describe _how_ the fields must be encoded. This
+  could be through an identifier that allows the LSP to lookup the values
+  associated to the `promise`. It is recommended to encode the raw values of the
+  fields inside the `promise` string, so the LSP can be stateless.
 * SHOULD use a cryptographically-verifiable method of generating
   `promise`, such as a MAC of some deterministic serialization of the
   other `opening_fee_params` keys, then encoded in hexadecimal, base64,
@@ -340,6 +346,15 @@ The LSP, when generating the `promise` field:
 > **Rationale** The method to generate `promise` is left vague in order
 > to allow LSP implementors the flexibility to structure their code
 > as necessary.
+>
+> The LSP should be able to extract all the information in the
+> `opening_fee_params` object from the `promise` to allow a clear upgrade path.
+> If this would not be the case, if ever a field is added to the
+> `opening_fee_params` object, clients may not know about the new field and they
+> may send back an `opening_fee_params` object without the newly added field in
+> the `lsps2.buy` call. The LSP would only be able to verify the `promise` if
+> the field was encoded in the `promise` itself.
+>
 > The above specification suggests the use of any MAC, which would cover
 > the above requirements, and requires a symmetric key known only by
 > the LSP.


### PR DESCRIPTION
This PR makes the `opening_fee_params` objects extensible for future backward compatible upgrades. Fixes https://github.com/BitcoinAndLightningLayerSpecs/lsp/issues/94

## The problem
If this spec ever decides to add an additional field in the `opening_fee_params` object, this upgrade path is impossible to roll out in the current spec, without placing too much logic on the client side. 

### LSP is upgraded, client is not
- The LSP constructs a new `opening_fee_params` object, containing the new field. Commits to the object in the `promise`.
- The client deserializes the object, not knowing about the new field
- The client serializes the object again and sends it back to the LSP without the new field
- The LSP is now unable to verify the promise

Note that it would be possible for the client to send back the `opening_fee_params` object using exactly the bytes it received from the LSP. But this is a 'hard' constraint, because this would force the client to pass to the UI layer the deserialized object _plus_ an additional field containing the raw `opening_fee_params` bytes.

## The solution
Encode all fields into the promise itself. This way, the promise alone is enough for the LSP to retrieve what it committed to. And the client really only needs to send back the `promise` to the LSP.

### LSP is upgraded, client is not
- The LSP constructs a new `opening_fee_params` object, containing the new field. Commits to the object in the `promise`.
- The client deserializes the object, not knowing about the new field.
- The client sends `promise` to the LSP, this promise contains the new field encoded.
- The LSP is now able to verify the promise.

## Notes
- I removed the constraint that the LSP is not allowed to add any fields to the `opening_fee_params` object, because the LSP could commit to any data unknown to the client, even outside of these communications. SO I don't think it adds much value to have this constraint in the spec.
- I modified the name of the `invalid_opening_fee_params` error to `invalid_promise`, keeping the same error number
- This is a breaking change, we discussed during the in-person meeting in Viareggio, this would be the last breaking change to LSPS2. Thankfully this change may help avoid breaking changes in the future when LSPS2 may already be used by multiple implementations.