### PR TITLE
LSPS6: LSP meta-data.

### DIFF
--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -1,0 +1,131 @@
+# LSPS6
+
+| Name    | `.well-known`      |
+| ------- |--------------------|
+| Version | 1                  |
+| Status  | For Implementation |
+
+## Motivation
+
+The purpose is to provide a standard way for clients to obtain extra information from the LSP.
+There might be information that is not available through regular LSPS messages.
+An example for such information could be the pricing strategy for LSPS1.
+Optionally there is also a mechanism to show authoritatively that the information
+is coming from the LSP in order to prevent spoofing.
+
+### Actors
+
+The 'LSP' is the API provider, and acts as the server.
+The 'client' is the API consumer.
+
+## Well-Known URI
+
+[Well-known URIs][] are a way to discover information about a service.
+The LSP SHOULD serve a well-known URI `/.well-known/bitcoin` to allow for public key discovery.
+
+```json
+{
+  "icon": "https://acme.com/icon.png",
+  "logo": "https://acme.com/logo.png",
+  "email": "support@acme.com",
+  "nostr": "npub1w...s2mfp9",
+  "twitter": "@acme",
+  "telegram": "@acme",
+  "lightning": {
+    "mainnet": {
+      "public_keys": [
+        "0326e6...2833a3",
+        "0305f5...2e4e45"
+      ]
+    },
+    "testnet": {
+      "public_keys": [
+        "03f060...869c00"
+      ]
+    },
+    ...
+  },
+
+}
+```
+
+- `icon` LSP MAY include the URL of its icon.
+- `logo` LSP MAY include the URL of its logo.
+- `email` LSP MAY include its support email.
+- `nostr` LSP MAY include its nost public key.
+- `twitter` LSP MAY include its Twitter handle.
+- `telegram` LSP MAY include its Telegram handle.
+- `lightning`
+  - `mainnet` LSP SHOULD include its mainnet lightning node public keys.
+  - `testnet` LSP MAY include its testnet lightning node public keys.
+  - `...` LSP MAY include its public keys for other network types.
+
+[Well-known URIs]: https://datatracker.ietf.org/doc/html/rfc8615
+
+## API
+
+### lsps6.get_info
+
+`lsps6.get_info` provides generic information about the LSP.
+
+The client SHOULD use the data in `url` up until the [TLD][] and append `/.well-known/bitcoin`.
+So assuming the URL is `https://acme.com/lsp`, the client MUST use `https://acme.com/.well-known/bitcoin`.
+To confirm authority the client MUST crawl this URL and
+match the public key from the LSP with the public key from the well-known URI.
+
+[TLD]: https://en.wikipedia.org/wiki/Top-level_domain
+
+Any information that is available in the response of `lsps6.get_info`
+should override the information in the well-known URI as it's more authoritative.
+
+If there is a piece of information unavailable,
+the client SHOULD use the information from the well-known URI as a fallback.
+
+**Request** No parameters needed.
+
+**Response**
+
+```JSON
+{
+  "url": "https://acme.com/lsp",
+  "icon": "https://acme.com/lsp-icon.png",
+  "logo": "https://acme.com/lsp-logo.png",
+  "email": "lsp-support@acme.com",
+  "nostr": "npub1w...s2mfp9",
+  "twitter": "@acme-lsp",
+  "telegram": "@acme-lsp"
+}
+```
+
+- `url` LSP SHOULD include the URL of its website.
+- `icon` LSP MAY include the URL of its icon.
+- `logo` LSP MAY include the URL of its logo.
+- `email` LSP MAY include its support email.
+- `nostr` LSP MAY include its nost public key.
+- `twitter` LSP MAY include its Twitter handle.
+- `telegram` LSP MAY include its Telegram handle.
+
+### lsps6.get_lsp_info
+
+`lsps6.get_lsp_info` provides generic information about an LSPS spec.
+
+**Request**
+```JSON
+{
+  "spec": "LSPS1"
+}
+```
+
+**Response**
+
+```JSON
+{
+  "short": "Short description",
+  "long": "Longer description of the details"
+}
+```
+
+LSP MUST always respond even when there is no support for a spec. LSP MUST include the following fields
+(field values can be empty):
+- `short` is a short description of the details with no formatting. With a maximum of 64 characters.
+- `long` is a long description of the details with md formatting. With a maximum of 1024 characters.

--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -13,8 +13,7 @@ LSPS6 requires [BOLT8][] as a transport layer.
 
 Not all information is available through regular LSPS messages.
 In order to provide more transparency, LSPS6 provides the ability to deliver extra information.
-An example for such information could be the pricing strategy for LSPS1.
-This extra information can be in the form of a short description about a specific LSPS, a URL and/or an email address.
+This extra information can be in the form of a URL, icon, logo and/or a support email address.
 We need to be conscious about information spoofing.
 
 ### Actors
@@ -70,28 +69,3 @@ The LSP can choose to include a URL to a specific page that provides more inform
   Often the icon is the logo without the text to fit in a square shape.
 - `logo` LSP MAY include the URL of its logo with a maximum length of 128 characters.
 - `email` LSP MAY include its support email.
-
-### lsps6.get_lsp_info
-
-`lsps6.get_lsp_info` provides generic additional information about an LSPS spec.
-
-**Request**
-```JSON
-{
-  "spec": "LSPS1"
-}
-```
-
-**Response**
-
-```JSON
-{
-  "short": "Short description",
-  "long": "Longer description of the details"
-}
-```
-
-LSP MUST always respond even when there is no support for a spec. LSP MUST include the following fields
-(field values can be empty):
-- `short` is a short description of the additional details with no formatting. With a maximum of 64 characters.
-- `long` is a long description of the additional details with md formatting. With a maximum of 1024 characters.

--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -44,8 +44,7 @@ The LSP SHOULD serve a well-known URI `/.well-known/bitcoin` to allow for public
       ]
     },
     ...
-  },
-
+  }
 }
 ```
 

--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -62,10 +62,10 @@ Any provided URLs should be valid and reachable. So starting with `http(s)://`.
 ```
 
 - `url` LSP SHOULD include the URL to its website with a maximum length of 64 characters.
-The LSP can choose to include a URL to a specific page that provides more information about the LSP or simple a top level domain.
-- `is_dns_verification_available` LSP MAY include a boolean to indicate if the LSP has DNS Public Key Verification.
-- `icon` LSP MAY include the URL of its icon with a maximum length of 128 characters.
+  The LSP can choose to include a URL to a specific page that provides more information about the LSP or simple a top level domain.
+- `is_dns_verification_available` is an **optional** boolean field, if present it's purpose is to indicate if the LSP supports DNS Public Key Verification.
+- `icon` is an **optional** field, if present it contains the URL to an icon with a maximum length of 128 characters.
   Icon is a squarely shaped smaller representation of the logo.
   Often the icon is the logo without the text to fit in a square shape.
-- `logo` LSP MAY include the URL of its logo with a maximum length of 128 characters.
-- `email` LSP MAY include its support email.
+- `logo` is an **optional** field, if present it contains the URL to a logo with a maximum length of 128 characters.
+- `email` is an **optional** field, if present it contains the support email address.

--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -61,11 +61,15 @@ Any provided URLs should be valid and reachable. So starting with `http(s)://`.
 }
 ```
 
-- `url` LSP SHOULD include the URL to its website with a maximum length of 64 characters.
-  The LSP can choose to include a URL to a specific page that provides more information about the LSP or simple a top level domain.
+- `url` LSP SHOULD include the URL to its website with a maximum URL length of 64 characters.
+  The LSP can choose to include a URL to a specific page that provides more information about the LSP or a top level domain.
 - `is_dns_verification_available` is an **optional** boolean field, if present it's purpose is to indicate if the LSP supports DNS Public Key Verification.
-- `icon` is an **optional** field, if present it contains the URL to an icon with a maximum length of 128 characters.
+- `icon` is an **optional** field, if present it contains the URL to an icon with a maximum URL length of 128 characters.
   Icon is a squarely shaped smaller representation of the logo.
   Often the icon is the logo without the text to fit in a square shape.
-- `logo` is an **optional** field, if present it contains the URL to a logo with a maximum length of 128 characters.
-- `email` is an **optional** field, if present it contains the support email address.
+  The maximum dimensions of the icon is 400 x 400px.
+  The minimum dimensions of the icon is 20 x 20px.
+- `logo` is an **optional** field, if present it contains the URL to a logo with a maximum URL length of 128 characters.
+  The maximum dimensions of the logo is 400 x 400px.
+  The minimum dimensions of the logo is 20 x 20px.
+- `email` is an **optional** field, if present it contains the support email address with a maximum length of 128 characters.

--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -1,9 +1,9 @@
 # LSPS6
 
-| Name    | `.well-known`      |
-| ------- |--------------------|
-| Version | 1                  |
-| Status  | For Implementation |
+| Name    | `.well-known` |
+| ------- |---------------|
+| Version | 1             |
+| Status  | Draft         |
 
 ## Motivation
 
@@ -87,6 +87,7 @@ the client SHOULD use the information from the well-known URI as a fallback.
 ```JSON
 {
   "url": "https://acme.com/lsp",
+  "well_known": true,
   "icon": "https://acme.com/lsp-icon.png",
   "logo": "https://acme.com/lsp-logo.png",
   "email": "lsp-support@acme.com",
@@ -97,12 +98,18 @@ the client SHOULD use the information from the well-known URI as a fallback.
 ```
 
 - `url` LSP SHOULD include the URL of its website.
+- `well_known` LSP MAY include a boolean to indicate if the LSP has a well-known URI.
+The default is that it does not support it.
 - `icon` LSP MAY include the URL of its icon.
+Icon is a squarely shaped smaller representation of the logo.
+Often the icon is the logo without the text to fit in a square shape.
 - `logo` LSP MAY include the URL of its logo.
 - `email` LSP MAY include its support email.
-- `nostr` LSP MAY include its nost public key.
-- `twitter` LSP MAY include its Twitter handle.
-- `telegram` LSP MAY include its Telegram handle.
+- `nostr` LSP MAY include its npub according to [NIP-19][].
+- `twitter` LSP MAY include its Twitter handle starting with an `@` sign.
+- `telegram` LSP MAY include its Telegram handle starting with an `@` sign.
+
+[NIP-19]: https://github.com/nostr-protocol/nips/blob/master/19.md
 
 ### lsps6.get_lsp_info
 

--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -25,12 +25,6 @@ The LSP SHOULD serve a well-known URI `/.well-known/bitcoin` to allow for public
 
 ```json
 {
-  "icon": "https://acme.com/icon.png",
-  "logo": "https://acme.com/logo.png",
-  "email": "support@acme.com",
-  "nostr": "npub1w...s2mfp9",
-  "twitter": "@acme",
-  "telegram": "@acme",
   "lightning": {
     "mainnet": {
       "public_keys": [
@@ -48,14 +42,6 @@ The LSP SHOULD serve a well-known URI `/.well-known/bitcoin` to allow for public
 }
 ```
 
-- `icon` LSP MAY include the URL of its icon.
-  Icon is a squarely shaped smaller representation of the logo.
-  Often the icon is the logo without the text to fit in a square shape.
-- `logo` LSP MAY include the URL of its logo.
-- `email` LSP MAY include its support email.
-- `nostr` LSP MAY include its  npub according to [NIP-19][].
-- `twitter` LSP MAY include its Twitter handle starting with an `@` sign.
-- `telegram` LSP MAY include its Telegram handle starting with an `@` sign.
 - `lightning`
   - `mainnet` LSP SHOULD include its mainnet lightning node public keys.
   - `testnet` LSP MAY include its testnet lightning node public keys.
@@ -77,12 +63,6 @@ match the public key from the LSP with the public key from the well-known URI.
 
 [TLD]: https://en.wikipedia.org/wiki/Top-level_domain
 
-Any information that is available in the response of `lsps6.get_info`
-should override the information in the well-known URI as it's more authoritative.
-
-If there is a piece of information unavailable,
-the client SHOULD use the information from the well-known URI as a fallback.
-
 **Request** No parameters needed.
 
 **Response**
@@ -93,10 +73,7 @@ the client SHOULD use the information from the well-known URI as a fallback.
   "well_known": true,
   "icon": "https://acme.com/lsp-icon.png",
   "logo": "https://acme.com/lsp-logo.png",
-  "email": "lsp-support@acme.com",
-  "nostr": "npub1w...s2mfp9",
-  "twitter": "@acme-lsp",
-  "telegram": "@acme-lsp"
+  "email": "lsp-support@acme.com"
 }
 ```
 
@@ -108,9 +85,6 @@ Icon is a squarely shaped smaller representation of the logo.
 Often the icon is the logo without the text to fit in a square shape.
 - `logo` LSP MAY include the URL of its logo.
 - `email` LSP MAY include its support email.
-- `nostr` LSP MAY include its npub according to [NIP-19][].
-- `twitter` LSP MAY include its Twitter handle starting with an `@` sign.
-- `telegram` LSP MAY include its Telegram handle starting with an `@` sign.
 
 ### lsps6.get_lsp_info
 

--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -49,17 +49,20 @@ The LSP SHOULD serve a well-known URI `/.well-known/bitcoin` to allow for public
 ```
 
 - `icon` LSP MAY include the URL of its icon.
+  Icon is a squarely shaped smaller representation of the logo.
+  Often the icon is the logo without the text to fit in a square shape.
 - `logo` LSP MAY include the URL of its logo.
 - `email` LSP MAY include its support email.
-- `nostr` LSP MAY include its nost public key.
-- `twitter` LSP MAY include its Twitter handle.
-- `telegram` LSP MAY include its Telegram handle.
+- `nostr` LSP MAY include its  npub according to [NIP-19][].
+- `twitter` LSP MAY include its Twitter handle starting with an `@` sign.
+- `telegram` LSP MAY include its Telegram handle starting with an `@` sign.
 - `lightning`
   - `mainnet` LSP SHOULD include its mainnet lightning node public keys.
   - `testnet` LSP MAY include its testnet lightning node public keys.
   - `...` LSP MAY include its public keys for other network types.
 
 [Well-known URIs]: https://datatracker.ietf.org/doc/html/rfc8615
+[NIP-19]: https://github.com/nostr-protocol/nips/blob/master/19.md
 
 ## API
 
@@ -108,8 +111,6 @@ Often the icon is the logo without the text to fit in a square shape.
 - `nostr` LSP MAY include its npub according to [NIP-19][].
 - `twitter` LSP MAY include its Twitter handle starting with an `@` sign.
 - `telegram` LSP MAY include its Telegram handle starting with an `@` sign.
-
-[NIP-19]: https://github.com/nostr-protocol/nips/blob/master/19.md
 
 ### lsps6.get_lsp_info
 

--- a/LSPS6/README.md
+++ b/LSPS6/README.md
@@ -25,18 +25,18 @@ The 'client' is the API consumer.
 
 [BIP353][] provides a way to discover payment instructions over DNS.
 Analogous to this the LSP SHOULD create a DNS TXT records in the form of
-`lsps.acme.com. 3600 IN TXT "public_key:0326e6...2833a3"` for public key verification.
+`lsps6.acme.com. 3600 IN TXT "public_key:0326e692c455dd554c709bbb470b0ca7e0bb04152f777d1445fd0bf3709a2833a3"` for public key verification.
 If the LSP has multiple lightning network nodes, then the LSP SHOULD create multiple corresponding TXT records.
-If the LSP has multiple domains which is wishes to reference to, then the LSP SHOULD create multiple corresponding TXT records for each domain.
-In the given example `0326e6...2833a3` should be replaced with the lightning network nodes' public key of the LSP (in zbase32 format).
-The LSP must replace `acme.com` in `lsps.acme.com.` with their own domain.
+If the LSP has multiple domains which it wishes to reference to, then the LSP SHOULD create multiple corresponding TXT records for each domain.
+In the given example `0326e692c455dd554c709bbb470b0ca7e0bb04152f777d1445fd0bf3709a2833a3` should be replaced with the lightning network nodes' public key of the LSP (in zbase32 format).
+The LSP must replace `acme.com` in `lsps6.acme.com.` with their own domain.
 Any TXT record not starting with `public_key:` can be ignored by the client.
 
 The response from [lsps6.get_info](#lsps6get_info) may contain URLs and/or an email address in it's response.
 When the LSP indicates support for DNS Public Key Verification via the flag is_dns_verification_available then
-the client MUST confirm authenticity by verify the public key(s) from the domain's DNS record(s)
+the client SHOULD confirm authenticity by verify the public key(s) from the domain's DNS record(s)
 with the public key that sends the [BOLT8][] messages.
-The client MUST verify all distinct domains.
+The client SHOULD verify all distinct domains.
 
 [BIP353]: https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki
 
@@ -61,15 +61,20 @@ Any provided URLs should be valid and reachable. So starting with `http(s)://`.
 }
 ```
 
-- `url` LSP SHOULD include the URL to its website with a maximum URL length of 64 characters.
+- `url` LSP SHOULD include the encoded URL to its website with a maximum URL length of 256 characters.
   The LSP can choose to include a URL to a specific page that provides more information about the LSP or a top level domain.
-- `is_dns_verification_available` is an **optional** boolean field, if present it's purpose is to indicate if the LSP supports DNS Public Key Verification.
+- `is_dns_verification_available` is an **optional** boolean (true/false) field, if present it's purpose is to indicate if the LSP supports DNS Public Key Verification. True signals support and when omitted or false then the LSP does not support DNS Public Key Verification.
 - `icon` is an **optional** field, if present it contains the URL to an icon with a maximum URL length of 128 characters.
   Icon is a squarely shaped smaller representation of the logo.
   Often the icon is the logo without the text to fit in a square shape.
   The maximum dimensions of the icon is 400 x 400px.
   The minimum dimensions of the icon is 20 x 20px.
+  So any square dimension between 20px and 400px is allowed.
 - `logo` is an **optional** field, if present it contains the URL to a logo with a maximum URL length of 128 characters.
   The maximum dimensions of the logo is 400 x 400px.
   The minimum dimensions of the logo is 20 x 20px.
-- `email` is an **optional** field, if present it contains the support email address with a maximum length of 128 characters.
+- `email` is an **optional** field, if present it contains the support email address with a maximum length of 128 characters. The email address format requirements are in accordance with [RFC5322 Section 3.4.1][]
+
+Every field marked as optional and is not used MUST be omitted.
+
+[RFC5322]:  https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1


### PR DESCRIPTION
I've expanded `/.well-known/bitcoin` a bit to make it attractive for other use-cases beyond LSPS. (since the URI is proposed with `/.well-known/bitcoin` and not something like `/.well-known/lightning-lsp`)
But if nobody can envision any value for a generic bitcoin named well-known URI, we can change it.