### PR TITLE
wiki: Add libraries and services

### DIFF
--- a/wiki/Libraries-Services.md
+++ b/wiki/Libraries-Services.md
@@ -1,0 +1,16 @@
+# Libraries & Service
+
+Libraries and services that support the LSPSpec in no specific order.
+
+## Libraries
+
+- [LDK - lightning liquidity](https://github.com/lightningdevkit/lightning-liquidity) LSPS0, LSPS1, LSPS2
+- [LND - balanceofsatoshi](https://github.com/alexbosworth/balanceofsatoshis/tree/master/lsp) LSPS0, LSPS1
+- [CLN - cln-lightning-liquidity](https://github.com/niteshbalusu11/cln-lightning-liquidity) LSPS0, LSPS1
+- [CLN/LND - Breez lspd](https://github.com/breez/lspd) LSPS0, LSPS2
+
+## Services
+
+| Node                 | Specs       | Status           |
+| -------------------- | ----------- | ---------------- |
+| c= (027100...b54190) | LSPS2       | Testing / Signet |

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,3 +1,4 @@
 - [Home](Home)
+- [Libraries & Services](Libraries-Services.md)
 - [Implementation Notes](Implementation-Notes)
 - [Wiki Contributions](Wiki-Contributions)


### PR DESCRIPTION
Add LSPSpec libraries and services to the wiki. Replaces #98 and #92.

FYI: @npslaney @tnull @niteshbalusu11 @alexbosworth @JssDWt