### PR TITLE
LSPS1/LSPS2: Add LSPS0 Required Note

### DIFF
--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -6,6 +6,8 @@
 | Version 	| 1                             |
 | Status    | For Implementation            |
 
+LSPS1 requires [LSPS0](../LSPS0/) and therefore [BOLT8](https://github.com/lightning/bolts/blob/f7dcc32694b8cd4f3a1768b904f58cb177168f29/08-transport.md) as a transport layer.
+
 
 ## Motivation
 

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -6,7 +6,7 @@
 | Version 	| 1                             |
 | Status    | For Implementation            |
 
-LSPS1 requires [LSPS0](../LSPS0/) and therefore [BOLT8](https://github.com/lightning/bolts/blob/f7dcc32694b8cd4f3a1768b904f58cb177168f29/08-transport.md) as a transport layer.
+LSPS1 requires [LSPS0](../LSPS0/) and therefore [BOLT8](https://github.com/lightning/bolts/blob/master/08-transport.md) as a transport layer.
 
 
 ## Motivation

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -5,6 +5,10 @@
 | Version | 1                        |
 | Status  | For Implementation       |
 
+
+LSPS2 requires [LSPS0](../LSPS0/) and therefore [BOLT8](https://github.com/lightning/bolts/blob/f7dcc32694b8cd4f3a1768b904f58cb177168f29/08-transport.md) as a transport layer.
+
+
 > **Note** Nodes that naively prepayment probe can cause LSPs using LSPS2 to open channels early.
 > Naive prepayment probing logic is being updated to greatly reduce the possibility of this happening.
 >

--- a/LSPS2/README.md
+++ b/LSPS2/README.md
@@ -6,7 +6,7 @@
 | Status  | For Implementation       |
 
 
-LSPS2 requires [LSPS0](../LSPS0/) and therefore [BOLT8](https://github.com/lightning/bolts/blob/f7dcc32694b8cd4f3a1768b904f58cb177168f29/08-transport.md) as a transport layer.
+LSPS2 requires [LSPS0](../LSPS0/) and therefore [BOLT8](https://github.com/lightning/bolts/blob/master/08-transport.md) as a transport layer.
 
 
 > **Note** Nodes that naively prepayment probe can cause LSPs using LSPS2 to open channels early.


### PR DESCRIPTION
After multiple people implementing LSPS1 via http, the group acknowledged to add a note to LSPS1/LSPS2 that LSPS0 is an important requirement for implementation.

This PR adds these two notes.