### PR TITLE
LSPS1: Deprecated invoice CANCELLED state

### DIFF
--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -342,7 +342,10 @@ The LSP MAY omit payment options.
     - `HOLD` Lighting payment arrived, preimage NOT released.
     - `PAID`  When the has been preimage released
     - `REFUNDED` Lightning payment has been refunded.
-    - `CANCELLED` Lightning payment has been cancelled
+    - <del>`CANCELLED` Lightning payment has been cancelled.</del> This state has been deprecated.
+      - You MUST use `REFUNDED` for a cancelled or refunded invoice.
+      - Earlier versions of this spec MAY still use this state. 
+      - Clients SHOULD still support this state for backwards compatibility.
 - `expires_at` <[LSPS0.datetime][]> The timestamp at which the payment option for this order expires
 - `fee_total_sat` <[LSPS0.sat][]> The total fee the LSP will charge to open this channel in satoshi.
 - `order_total_sat` <[LSPS0.sat][]> What the client needs to pay in total to open the requested channel.

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -343,7 +343,7 @@ The LSP MAY omit payment options.
     - `PAID`  When the has been preimage released
     - `REFUNDED` Lightning payment has been refunded.
     - <del>`CANCELLED` Lightning payment has been cancelled.</del> This state has been deprecated.
-      - You MUST use `REFUNDED` for a cancelled or refunded invoice.
+      - The LSP MUST use `REFUNDED` for a cancelled or refunded invoice.
       - Earlier versions of this spec MAY still use this state. 
       - Clients SHOULD still support this state for backwards compatibility.
 - `expires_at` <[LSPS0.datetime][]> The timestamp at which the payment option for this order expires


### PR DESCRIPTION
As discussed in the last LSPSpec call, this PR deprecates the `CANCELLED` state for lightning invoices payments. The reason for this is that it is technically redundant to the `REFUNDED` state. 

This change is backwards compatible.